### PR TITLE
CFINSPEC-389: Updated k8sobject resource to add resource_id property and adds and updates matchers.

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_object.md
+++ b/docs-chef-io/content/inspec/resources/k8s_object.md
@@ -38,7 +38,7 @@ end
 ## Properties
 
 `uid`
-: UID of the resource. 
+: UID of the resource.
 
 `name`
 : Name of the resource.
@@ -60,7 +60,7 @@ end
 ### Test to ensure kube-system, kube-public, and default namespaces exist
 
 ```ruby
- describe k8sobject(api: 'v1', type: 'namespaces', name: 'kube-system') do
+describe k8sobject(api: 'v1', type: 'namespaces', name: 'kube-system') do
   it { should exist }
 end
 ```
@@ -76,3 +76,15 @@ end
 ## Matchers
 
 {{% inspec/inspec_matchers_link %}}
+
+### have_label
+
+The `have_label` matcher verifies if the given key and value is present in the resource lables.
+
+    it { should have_label('foo', 'bar') }
+
+### have_annotation
+
+The `have_annotation` matcher verifies if the given key and value is present in the resource annotations.
+
+    it { should have_annotation('foo', 'bar') }

--- a/docs-chef-io/content/inspec/resources/k8s_object.md
+++ b/docs-chef-io/content/inspec/resources/k8s_object.md
@@ -47,13 +47,13 @@ end
 : Namespace of the resource.
 
 `resource_version`
-: resource version of the resource.
+: Resource version of the resource.
 
 `kind`
-: resource type.
+: Resource type.
 
 `metadata`
-: metadata for the resource.
+: Metadata for the resource.
 
 `labels`
 : Labels of the resource.
@@ -87,10 +87,14 @@ end
 
 The `have_label` matcher verifies if the specified key and value are present in the resource lables.
 
-    it { should have_label('foo', 'bar') }
+```ruby
+it { should have_label('foo', 'bar') }
+```
 
 ### have_annotation
 
 The `have_annotation` matcher verifies if the specified key and value are present in the resource annotations.
 
-    it { should have_annotation('foo', 'bar') }
+```ruby
+it { should have_annotation('foo', 'bar') }
+```

--- a/docs-chef-io/content/inspec/resources/k8s_object.md
+++ b/docs-chef-io/content/inspec/resources/k8s_object.md
@@ -79,12 +79,12 @@ end
 
 ### have_label
 
-The `have_label` matcher verifies if the given key and value is present in the resource lables.
+The `have_label` matcher verifies if the specified key and value are present in the resource lables.
 
     it { should have_label('foo', 'bar') }
 
 ### have_annotation
 
-The `have_annotation` matcher verifies if the given key and value is present in the resource annotations.
+The `have_annotation` matcher verifies if the specified key and value are present in the resource annotations.
 
     it { should have_annotation('foo', 'bar') }

--- a/docs-chef-io/content/inspec/resources/k8s_object.md
+++ b/docs-chef-io/content/inspec/resources/k8s_object.md
@@ -55,6 +55,12 @@ end
 `metadata`
 : metadata for the resource.
 
+`labels`
+: Labels of the resource.
+
+`annotations`
+: Annotations of the resource.
+
 ## Examples
 
 ### Test to ensure kube-system, kube-public, and default namespaces exist

--- a/docs-chef-io/content/inspec/resources/k8s_objects.md
+++ b/docs-chef-io/content/inspec/resources/k8s_objects.md
@@ -44,13 +44,13 @@ end
 : Namespace of the resource.
 
 `resource_versions`
-: resource version of the resource.
+: Resource version of the resource.
 
 `kinds`
-: resource type.
+: Resource type.
 
 `metadatas`
-: metadata for the resource.
+: Metadata for the resource.
 
 ## Examples
 

--- a/docs-chef-io/content/inspec/resources/k8s_pods.md
+++ b/docs-chef-io/content/inspec/resources/k8s_pods.md
@@ -11,7 +11,7 @@ identifier = "inspec/resources/k8s/K8s Pods"
 parent = "inspec/resources/k8s"
 +++
 
-Use the `k8s_pods` Chef InSpec audit resource to test the configuration of all Pods in a namespace.
+Use the `k8s_pods` Chef InSpec audit resource to test the configurations of all Pods in a namespace.
 
 ## Installation
 

--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -74,6 +74,7 @@ module Inspec
       end
 
       def has_label?(objlabel = nil, value = nil)
+        # Earlier only key was verified. Accepting value as nil just for the backward compatibility.
         if value.nil?
           @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:labels) && @k8sobject.metadata.labels.respond_to?(objlabel) && !@k8sobject.metadata.labels[objlabel].nil?
         else

--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -81,8 +81,8 @@ module Inspec
         false
       end
 
-      def has_annotation?(objlabel = nil, value)
-        if @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objlabel) && @k8sobject.metadata.annotations[objlabel] == value
+      def has_annotation?(objkey = nil, value)
+        if @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objkey) && @k8sobject.metadata.annotations[objkey] == value
           return true
         end
 

--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -44,7 +44,7 @@ module Inspec
       end
 
       delegate :kind, :metadata, to: :resource
-      delegate :uid, :name, :namespace, :resourceVersion, :labels, :annotations, :creationTimestamp, to: :metadata
+      delegate :uid, :name, :namespace, :resourceVersion, :creationTimestamp, to: :metadata
 
       alias resource_version resourceVersion
 
@@ -82,12 +82,25 @@ module Inspec
         end
       end
 
-      def has_annotation?(objkey = nil, value)
-        @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objkey) && @k8sobject.metadata.annotations[objkey] == value
+      def has_annotation?(objkey = nil, value = nil)
+        # values sometimes are very long descriptions in such cases user might want to only search with key.
+        if value.nil?
+          @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objkey) && !@k8sobject.metadata.annotations[objkey].nil?
+        else
+          @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objkey) && @k8sobject.metadata.annotations[objkey] == value
+        end
       end
 
       def exists?
         !@k8sobject.nil?
+      end
+
+      def labels
+        k8sobject.metadata.labels.to_h
+      end
+
+      def annotations
+        @k8sobject.metadata.annotations.to_h
       end
 
       def resource_id

--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -73,20 +73,16 @@ module Inspec
         false
       end
 
-      def has_label?(objlabel = nil, value)
-        if @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:labels) && @k8sobject.metadata.labels.respond_to?(objlabel) && @k8sobject.metadata.labels[objlabel] == value
-          return true
+      def has_label?(objlabel = nil, value = nil)
+        if value.nil?
+          @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:labels) && @k8sobject.metadata.labels.respond_to?(objlabel) && !@k8sobject.metadata.labels[objlabel].nil?
+        else
+          @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:labels) && @k8sobject.metadata.labels.respond_to?(objlabel) && @k8sobject.metadata.labels[objlabel] == value
         end
-
-        false
       end
 
       def has_annotation?(objkey = nil, value)
-        if @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objkey) && @k8sobject.metadata.annotations[objkey] == value
-          return true
-        end
-
-        false
+        @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objkey) && @k8sobject.metadata.annotations[objkey] == value
       end
 
       def exists?

--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -73,8 +73,16 @@ module Inspec
         false
       end
 
-      def has_label?(objlabel = nil)
-        if @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:labels) && @k8sobject.metadata.labels.respond_to?(objlabel) && !@k8sobject.metadata.labels[objlabel].nil?
+      def has_label?(objlabel = nil, value)
+        if @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:labels) && @k8sobject.metadata.labels.respond_to?(objlabel) && @k8sobject.metadata.labels[objlabel] == value
+          return true
+        end
+
+        false
+      end
+
+      def has_annotation?(objlabel = nil, value)
+        if @k8sobject.respond_to?(:metadata) && @k8sobject.metadata.respond_to?(:annotations) && @k8sobject.metadata.annotations.respond_to?(objlabel) && @k8sobject.metadata.annotations[objlabel] == value
           return true
         end
 
@@ -83,6 +91,10 @@ module Inspec
 
       def exists?
         !@k8sobject.nil?
+      end
+
+      def resource_id
+        uid || ""
       end
 
       def to_s

--- a/libraries/k8sobjects.rb
+++ b/libraries/k8sobjects.rb
@@ -93,8 +93,8 @@ module Inspec
         hash = obj.to_h
         hash[:status] = hash[:status].to_h
         hash.merge!(obj.metadata.to_h.transform_keys { |key| key.to_s.underscore.to_sym })
-        hash[:labels] = obj.metadata.labels&.map(&:to_h)
-        hash[:annotations] = obj.metadata.annotations&.map(&:to_h)
+        hash[:labels] = obj.metadata.labels.to_h
+        hash[:annotations] = obj.metadata.annotations.to_h
         hash
       end
     end

--- a/test/unit/libraries/k8sobject_test.rb
+++ b/test/unit/libraries/k8sobject_test.rb
@@ -16,8 +16,8 @@ class K8sObjectTest < ResourceTest
               name: 'pod1',
               namespace: 'default',
               resourceVersion: 1234,
-              annotations: {test_annotation1: "abc"},
-              labels: {test_label1: "xyz"}
+              annotations: {"test_annotation1" => "abc"},
+              labels: {}
             }
           }
         ]
@@ -47,12 +47,20 @@ class K8sObjectTest < ResourceTest
     assert_equal(1234, k8s_object.resource_version)
   end
 
+  def test_labels
+    assert_equal({}, k8s_object.labels)
+  end
+
   def test_has_label?
-    assert_equal(true, k8s_object.has_label?("test_label1", "xyz"))
+    assert_equal(false, k8s_object.has_label?("foo", "bar"))
   end
 
   def test_has_annotation?
     assert_equal(true, k8s_object.has_annotation?("test_annotation1", "abc"))
+  end
+
+  def test_has_annotation_only_key
+    assert_equal(true, k8s_object.has_annotation?("test_annotation1"))
   end
 
   def test_resource_id

--- a/test/unit/libraries/k8sobject_test.rb
+++ b/test/unit/libraries/k8sobject_test.rb
@@ -16,8 +16,8 @@ class K8sObjectTest < ResourceTest
               name: 'pod1',
               namespace: 'default',
               resourceVersion: 1234,
-              annotations: [],
-              labels: []
+              annotations: {test_annotation1: "abc"},
+              labels: {test_label1: "xyz"}
             }
           }
         ]
@@ -47,11 +47,15 @@ class K8sObjectTest < ResourceTest
     assert_equal(1234, k8s_object.resource_version)
   end
 
-  def test_labels
-    assert_empty(k8s_object.labels)
+  def test_has_label?
+    assert_equal(true, k8s_object.has_label?("test_label1", "xyz"))
   end
 
-  def annotations
-    assert_empty(k8s_object.annotations)
+  def test_has_annotation?
+    assert_equal(true, k8s_object.has_annotation?("test_annotation1", "abc"))
+  end
+
+  def test_resource_id
+    assert_equal('abcd1234', k8s_object.resource_id)
   end
 end

--- a/test/unit/libraries/k8sobjects_test.rb
+++ b/test/unit/libraries/k8sobjects_test.rb
@@ -16,8 +16,23 @@ class K8sObjectsTest < ResourceTest
               name: 'pod1',
               namespace: 'default',
               resourceVersion: 1234,
-              annotations: [],
-              labels: []
+              annotations: {"test_annotation1" => "foo"},
+              labels: {"test_label1" => "bar"}
+            }
+          },
+          {
+            name: 'pod2',
+            kind: 'pod',
+            status: {
+              phase: 'running'
+            },
+            metadata: {
+              uid: 'abcd4321',
+              name: 'pod2',
+              namespace: 'default',
+              resourceVersion: 4321,
+              annotations: {},
+              labels: {}
             }
           }
         ]
@@ -47,10 +62,10 @@ class K8sObjectsTest < ResourceTest
   end
 
   def test_labels
-    assert_empty(k8s_objects.labels.flatten)
+    assert_includes(k8s_objects.labels, { :test_label1 => "bar" })
   end
 
   def test_annotations
-    assert_empty(k8s_objects.annotations.flatten)
+    assert_includes(k8s_objects.annotations, { :test_annotation1 => "foo" },)
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Changes include
*  Fix`have_label` matcher to accept the key and value of the label.
* Adds `have_annotaton(key, value)` matcher
* Adds `resource_id` property.
* Updated property labels and annotations to return hash instead of k8s resource object.

```
describe k8sobject(api: 'v1', type: 'pods', namespace: 'default', name: 'inspec-nginx-demo-app-658f94696f-7h5r7') do
    it { should exist }
    its("name") { should cmp "inspec-nginx-demo-app-658f94696f-7h5r7"}
    it { should have_label("pod-template-hash", "658f94696f") }
    its("labels") { should include "foo" => "bar"}
    its("annotations") { should include "foo" => "bar"}
end
```

```
describe k8sobject(api: 'v1', type: 'nodes', name: 'minikube') do
  it { should exist }
  its("name") { should cmp "minikube"}
  it { should have_label("beta.kubernetes.io/os", "linux") }
  it { should have_annotation("node.alpha.kubernetes.io/ttl", "0") }
end
```

* Updated k8sobjects resource labels and annotations property to return hash into the []. It was returning nil earlier as it was treating the labels and annotations as array.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
