### PR TITLE
CFINSPEC-316: Support k8s node

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_node.md
+++ b/docs-chef-io/content/inspec/resources/k8s_node.md
@@ -12,7 +12,7 @@ platform = "k8s"
 +++
 
 
-Use the `k8s_node` Chef InSpec audit resource to test the configuration of k8s node.
+Use the `k8s_node` Chef InSpec audit resource to test the configuration of the K8s node.
 
 ## Installation
 
@@ -27,31 +27,31 @@ end
 ## Parameters
 
 `name`
-: Name of the Node
+: Node name.
 
 ## Properties
 
 `uid`
-: UID of the Node.
+: UID of the node.
 
 `kind`
-: Resource type of the Node.
+: Resource type of the node.
 
 `resource_version`
-: Resource version of the Node.
+: Resource version of the node.
 
 `labels`
-: Labels attached to Node.
+: Labels attached to the node.
 
 `annotations`
-: Annotations of the Node.
+: Annotations of the node.
 
 ## Examples
 
-### The node with the specified name should exist
+### Test to verify that the node with the specified name exists
 
 ```ruby
-describe k8s_node(name: "Node-Name") do
+describe k8s_node(name: "NODE_NAME") do
   it { should exist }
 end
 ```
@@ -62,7 +62,7 @@ end
 
 ### have_label
 
-The `have_label` matcher verifies if the specified key and value are present in the Node labels.
+The `have_label` matcher verifies if the specified key and value are present in the node labels.
 
 ```ruby
 it { should have_label('foo', 'bar') }
@@ -70,7 +70,7 @@ it { should have_label('foo', 'bar') }
 
 ### have_annotation
 
-The `have_annotation` matcher verifies if the specified key and value are present in the Node annotations.
+The `have_annotation` matcher verifies if the specified key and value are present in the node annotations.
 
 ```ruby
 it { should have_annotation('foo', 'bar') }

--- a/docs-chef-io/content/inspec/resources/k8s_node.md
+++ b/docs-chef-io/content/inspec/resources/k8s_node.md
@@ -12,52 +12,70 @@ platform = "k8s"
 +++
 
 
-Use the `k8s_node` Chef InSpec audit resource to test the configuration of...
+Use the `k8s_node` Chef InSpec audit resource to test the configuration of k8s node.
 
 ## Installation
 
 ## Syntax
 
 ```ruby
-describe k8s_node do
+describe k8s_node(name: "NAME") do
   #...
 end
 ```
 
 ## Parameters
 
-`PARAMETER`
-: PARAMETER DESCRIPTION
-
-`PARAMETER`
-: PARAMETER DESCRIPTION
+`name`
+: name of the Node
 
 ## Properties
 
-`PROPERTY`
-: PROPERTY DESCRIPTION
+`uid`
+: UID of the Node.
 
-`PROPERTY`
-: PROPERTY DESCRIPTION
+`kind`
+: type of k8s resource.
+
+`resource_version`
+: resource version of the Node.
+
+`labels`
+: labels attached to Node.
+
+`annotations`
+: metadata about the Node attached in the form of annotations.
 
 ## Examples
 
-**EXAMPLE DESCRIPTION**
+### The node with specified name shoule exist
 
 ```ruby
-describe k8s_node do
-  #...
-end
-```
-
-**EXAMPLE DESCRIPTION**
-
-```ruby
-describe k8s_node do
-  #...
+describe k8s_node(name: "My-Node") do
+  it { should exist }
 end
 ```
 
 ## Matchers
 
 {{% inspec/inspec_matchers_link %}}
+
+### have_label
+
+The `have_label` matcher verifies if the specified key and value are present in the Node lables.
+
+```ruby
+describe k8s_node(name: "My-Node") do
+  it { should have_label('foo', 'bar') }
+end
+```
+
+### have_annotation
+
+The `have_annotation` matcher verifies if the specified key and value are present in the Node annotations.
+
+```ruby
+describe k8s_node(name: "My-Node") do
+  it { should have_annotation('foo', 'bar') }
+end
+```

--- a/docs-chef-io/content/inspec/resources/k8s_node.md
+++ b/docs-chef-io/content/inspec/resources/k8s_node.md
@@ -35,16 +35,16 @@ end
 : UID of the Node.
 
 `kind`
-: type of k8s resource.
+: Resource type of the Node.
 
 `resource_version`
-: resource version of the Node.
+: Resource version of the Node.
 
 `labels`
-: labels attached to Node.
+: Labels attached to Node.
 
 `annotations`
-: metadata about the Node attached in the form of annotations.
+: Annotations of the Node.
 
 ## Examples
 

--- a/docs-chef-io/content/inspec/resources/k8s_node.md
+++ b/docs-chef-io/content/inspec/resources/k8s_node.md
@@ -27,7 +27,7 @@ end
 ## Parameters
 
 `name`
-: name of the Node
+: Name of the Node
 
 ## Properties
 
@@ -48,10 +48,10 @@ end
 
 ## Examples
 
-### The node with specified name shoule exist
+### The node with the specified name should exist
 
 ```ruby
-describe k8s_node(name: "My-Node") do
+describe k8s_node(name: "Node-Name") do
   it { should exist }
 end
 ```
@@ -62,12 +62,10 @@ end
 
 ### have_label
 
-The `have_label` matcher verifies if the specified key and value are present in the Node lables.
+The `have_label` matcher verifies if the specified key and value are present in the Node labels.
 
 ```ruby
-describe k8s_node(name: "My-Node") do
-  it { should have_label('foo', 'bar') }
-end
+it { should have_label('foo', 'bar') }
 ```
 
 ### have_annotation
@@ -75,7 +73,5 @@ end
 The `have_annotation` matcher verifies if the specified key and value are present in the Node annotations.
 
 ```ruby
-describe k8s_node(name: "My-Node") do
-  it { should have_annotation('foo', 'bar') }
-end
+it { should have_annotation('foo', 'bar') }
 ```

--- a/docs-chef-io/content/k8s_nodes.md
+++ b/docs-chef-io/content/k8s_nodes.md
@@ -39,7 +39,7 @@ end
 
 ## Examples
 
-### Verify nodes includes a node with a specified name and UID.
+### Verify nodes include a node with a specified name and UID.
 
 ```ruby
  describe k8s_nodes do

--- a/docs-chef-io/content/k8s_nodes.md
+++ b/docs-chef-io/content/k8s_nodes.md
@@ -11,7 +11,7 @@ identifier = "inspec/resources/k8s/K8s Nodes"
 parent = "inspec/resources/k8s"
 +++
 
-Use the `k8s_nodes` Chef InSpec audit resource to test the configuration of all Nodes.
+Use the `k8s_nodes` Chef InSpec audit resource to test the configuration of all nodes.
 
 ## Installation
 
@@ -26,26 +26,26 @@ end
 ## Properties
 
 `uids`
-: UID of the Nodes.
+: UID of the nodes.
 
 `names`
-: Name of the Nodes.
+: Name of the nodes.
 
 `resource_versions`
-: Resource version of the Nodes.
+: Resource version of the nodes.
 
 `kinds`
-: Resource type of the Nodes.
+: Resource type of the nodes.
 
 ## Examples
 
-### Verify nodes include a node with a specified name and UID.
+### Test to verify nodes include a node with a specified name and UID
 
 ```ruby
  describe k8s_nodes do
   it { should exist }
-  its('names') { should include 'node-name' }
-  its('uids') { should include 'uid-of-the-node' }
+  its('names') { should include 'NODE_NAME' }
+  its('uids') { should include 'NODE_UID' }
 end
 ```
 

--- a/docs-chef-io/content/k8s_nodes.md
+++ b/docs-chef-io/content/k8s_nodes.md
@@ -1,0 +1,54 @@
++++
+title = "k8s_nodes resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_nodes"
+identifier = "inspec/resources/k8s/K8s Nodes"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_nodes` Chef InSpec audit resource to test the configuration of all Nodes.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_nodes do
+  #...
+end
+```
+
+## Properties
+
+`uids`
+: UID of the Nodes.
+
+`names`
+: Name of the Nodes.
+
+`resource_versions`
+: Resource version of the Nodes.
+
+`kinds`
+: Resource type of the Nodes.
+
+## Examples
+
+### Verify nodes includes a node with a specified name and UID.
+
+```ruby
+ describe k8s_nodes do
+  it { should exist }
+  its('names') { should include 'node-name' }
+  its('uids') { should include 'uid-of-the-node' }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/libraries/k8s_node.rb
+++ b/libraries/k8s_node.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    class K8sNode < K8sObject
+      DEFAULT_NAMESPACE = nil
+
+      name 'k8s_node'
+      desc 'Verifies settings for a specific node'
+
+      example "
+      describe k8s_node(name: 'my-node') do
+        it { should exist }
+        its('name') { should eq 'my-node' }
+        ...
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'nodes'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8s_node.rb
+++ b/libraries/k8s_node.rb
@@ -4,6 +4,7 @@ require 'k8sobject'
 
 module Inspec
   module Resources
+    # k8s_node resource to get data about specific kubernetes node.
     class K8sNode < K8sObject
       DEFAULT_NAMESPACE = nil
 

--- a/libraries/k8s_nodes.rb
+++ b/libraries/k8s_nodes.rb
@@ -4,6 +4,7 @@ require 'k8sobjects'
 
 module Inspec
   module Resources
+    # k8s_nodes resource to get data about all kubernetes nodes
     class K8sNodes < K8sObjects
       DEFAULT_NAMESPACE = nil
 

--- a/libraries/k8s_nodes.rb
+++ b/libraries/k8s_nodes.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'k8sobjects'
+
+module Inspec
+  module Resources
+    class K8sNodes < K8sObjects
+      DEFAULT_NAMESPACE = nil
+
+      name 'k8s_nodes'
+      desc 'Verifies settings for all nodes'
+
+      example "
+      describe k8s_nodes do
+        it { should exist }
+        its('names') { should include 'my-node' }
+        its('uids') { should include '6a1a4d2f-0953-4115-8564-acd7bb63a786'}
+        ...
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'nodes'
+        super(opts)
+      end
+    end
+  end
+end

--- a/test/unit/libraries/k8s_node_test.rb
+++ b/test/unit/libraries/k8s_node_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'resource_test'
 
 class K8sNodeTest < ResourceTest
@@ -12,17 +14,17 @@ class K8sNodeTest < ResourceTest
               uid: 'abcd1234',
               name: 'node1',
               resourceVersion: 1234,
-              annotations: { annotation1: "value1" },
-              labels: { label1: "value1" }
+              annotations: { annotation1: 'value1' },
+              labels: { label1: 'value1' }
             }
           }
         ]
       }
     }
-  }
+  }.freeze
 
-  TYPE = 'nodes'.freeze
-  NAME = 'node1'.freeze
+  TYPE = 'nodes'
+  NAME = 'node1'
 
   def test_uid
     assert_equal('abcd1234', k8s_object.uid)
@@ -45,10 +47,10 @@ class K8sNodeTest < ResourceTest
   end
 
   def test_has_label?
-    assert_equal(true, k8s_object.has_label?("label1", "value1"))
+    assert_equal(true, k8s_object.has_label?('label1', 'value1'))
   end
 
   def test_has_annotation?
-    assert_equal(true, k8s_object.has_annotation?("annotation1", "value1"))
+    assert_equal(true, k8s_object.has_annotation?('annotation1', 'value1'))
   end
 end

--- a/test/unit/libraries/k8s_node_test.rb
+++ b/test/unit/libraries/k8s_node_test.rb
@@ -44,12 +44,11 @@ class K8sNodeTest < ResourceTest
     assert_equal(1234, k8s_object.resource_version)
   end
 
-  # TODO: Has dependency on PR https://github.com/inspec/inspec-k8s/pull/12 once that merged uncomment this test.
-  # def test_has_label?
-  #   assert_equal(true, k8s_object.has_label?("label1", "value1"))
-  # end
+  def test_has_label?
+    assert_equal(true, k8s_object.has_label?("label1", "value1"))
+  end
 
-  # def test_has_annotation?
-  #   assert_equal(true, k8s_object.has_annotation?("annotation1", "value1"))
-  # end
+  def test_has_annotation?
+    assert_equal(true, k8s_object.has_annotation?("annotation1", "value1"))
+  end
 end

--- a/test/unit/libraries/k8s_node_test.rb
+++ b/test/unit/libraries/k8s_node_test.rb
@@ -8,9 +8,6 @@ class K8sNodeTest < ResourceTest
           {
             name: 'node1',
             kind: 'node',
-            status: {
-              phase: 'running'
-            },
             metadata: {
               uid: 'abcd1234',
               name: 'node1',

--- a/test/unit/libraries/k8s_node_test.rb
+++ b/test/unit/libraries/k8s_node_test.rb
@@ -1,0 +1,58 @@
+require_relative 'resource_test'
+
+class K8sNodeTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        nodes: [
+          {
+            name: 'node1',
+            kind: 'node',
+            status: {
+              phase: 'running'
+            },
+            metadata: {
+              uid: 'abcd1234',
+              name: 'node1',
+              resourceVersion: 1234,
+              annotations: { annotation1: "value1" },
+              labels: { label1: "value1" }
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  TYPE = 'nodes'.freeze
+  NAME = 'node1'.freeze
+
+  def test_uid
+    assert_equal('abcd1234', k8s_object.uid)
+  end
+
+  def test_name
+    assert_equal('node1', k8s_object.name)
+  end
+
+  def test_namespace
+    assert_nil(k8s_object.namespace)
+  end
+
+  def test_kind
+    assert_equal('node', k8s_object.kind)
+  end
+
+  def test_resource_version
+    assert_equal(1234, k8s_object.resource_version)
+  end
+
+  # TODO: Has dependency on PR https://github.com/inspec/inspec-k8s/pull/12 once that merged uncomment this test.
+  # def test_has_label?
+  #   assert_equal(true, k8s_object.has_label?("label1", "value1"))
+  # end
+
+  # def test_has_annotation?
+  #   assert_equal(true, k8s_object.has_annotation?("annotation1", "value1"))
+  # end
+end

--- a/test/unit/libraries/k8s_nodes_test.rb
+++ b/test/unit/libraries/k8s_nodes_test.rb
@@ -24,7 +24,7 @@ class K8sNodesTest < ResourceTest
               uid: 'abcd4567',
               name: 'node2',
               resourceVersion: 4321,
-              annotations: {"foo" => "bar"},
+              annotations: {"foo1" => "bar1"},
               labels: {}
             }
           }
@@ -51,12 +51,15 @@ class K8sNodesTest < ResourceTest
     assert_includes(k8s_objects.resource_versions, 4321)
   end
 
-  # This needs to be uncommented once the PR raised to fix the labels and annotations values to return hash gets merged.
-  # def test_labels
-  #   assert_includes(k8s_objects.labels, { :foo => "bar" })
-  # end
+  def test_labels
+    assert_includes(k8s_objects.labels, { :foo => "bar" })
+  end
 
-  # def test_annotations
-  #   assert_includes(k8s_objects.annotations, {})
-  # end
+  def test_annotations
+    assert_includes(k8s_objects.annotations, {})
+  end
+
+  def test_annotations_has_given_values
+    assert_includes(k8s_objects.annotations, { :foo1 => "bar1" })
+  end
 end

--- a/test/unit/libraries/k8s_nodes_test.rb
+++ b/test/unit/libraries/k8s_nodes_test.rb
@@ -1,0 +1,62 @@
+require_relative 'resource_test'
+
+class K8sNodesTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        nodes: [
+          {
+            name: 'node1',
+            kind: 'node',
+            metadata: {
+              uid: 'abcd1234',
+              name: 'node1',
+              namespace: 'default',
+              resourceVersion: 1234,
+              annotations: {},
+              labels: { "foo" => "bar"}
+            }
+          },
+          {
+            name: 'node2',
+            kind: 'node',
+            metadata: {
+              uid: 'abcd4567',
+              name: 'node2',
+              resourceVersion: 4321,
+              annotations: {foo: 'bar'},
+              labels: {}
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  TYPE = 'nodes'.freeze
+
+  def test_uids
+    assert_includes(k8s_objects.uids, 'abcd1234')
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'node2')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'node')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, 4321)
+  end
+
+  # This needs to be modified once the issue for labels and annotation is fixed in the dependent PR
+  # def test_labels
+  #   assert_empty(k8s_objects.labels.flatten)
+  # end
+
+  # def test_annotations
+  #   assert_empty(k8s_objects.annotations.flatten)
+  # end
+end

--- a/test/unit/libraries/k8s_nodes_test.rb
+++ b/test/unit/libraries/k8s_nodes_test.rb
@@ -24,7 +24,7 @@ class K8sNodesTest < ResourceTest
               uid: 'abcd4567',
               name: 'node2',
               resourceVersion: 4321,
-              annotations: {foo: 'bar'},
+              annotations: {"foo" => "bar"},
               labels: {}
             }
           }
@@ -51,12 +51,12 @@ class K8sNodesTest < ResourceTest
     assert_includes(k8s_objects.resource_versions, 4321)
   end
 
-  # This needs to be modified once the issue for labels and annotation is fixed in the dependent PR
+  # This needs to be uncommented once the PR raised to fix the labels and annotations values to return hash gets merged.
   # def test_labels
-  #   assert_empty(k8s_objects.labels.flatten)
+  #   assert_includes(k8s_objects.labels, { :foo => "bar" })
   # end
 
   # def test_annotations
-  #   assert_empty(k8s_objects.annotations.flatten)
+  #   assert_includes(k8s_objects.annotations, {})
   # end
 end

--- a/test/unit/libraries/k8s_nodes_test.rb
+++ b/test/unit/libraries/k8s_nodes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'resource_test'
 
 class K8sNodesTest < ResourceTest
@@ -14,7 +16,7 @@ class K8sNodesTest < ResourceTest
               namespace: 'default',
               resourceVersion: 1234,
               annotations: {},
-              labels: { "foo" => "bar"}
+              labels: { foo: 'bar' }
             }
           },
           {
@@ -24,16 +26,16 @@ class K8sNodesTest < ResourceTest
               uid: 'abcd4567',
               name: 'node2',
               resourceVersion: 4321,
-              annotations: {"foo1" => "bar1"},
+              annotations: { foo1: 'bar1' },
               labels: {}
             }
           }
         ]
       }
     }
-  }
+  }.freeze
 
-  TYPE = 'nodes'.freeze
+  TYPE = 'nodes'
 
   def test_uids
     assert_includes(k8s_objects.uids, 'abcd1234')
@@ -52,7 +54,7 @@ class K8sNodesTest < ResourceTest
   end
 
   def test_labels
-    assert_includes(k8s_objects.labels, { :foo => "bar" })
+    assert_includes(k8s_objects.labels, { foo: 'bar' })
   end
 
   def test_annotations
@@ -60,6 +62,6 @@ class K8sNodesTest < ResourceTest
   end
 
   def test_annotations_has_given_values
-    assert_includes(k8s_objects.annotations, { :foo1 => "bar1" })
+    assert_includes(k8s_objects.annotations, { foo1: 'bar1' })
   end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR adds the `k8_node` and `k8s_nodes` resources.

* includes documentation for `k8s_node` and `k8s_nodes` resource
* includes a unit test for both the resources

```
 describe k8s_node(name: "foo") do
    it { should exist }
    its("name") { should cmp "foo"}
    it { should have_label("beta.kubernetes.io/os", "linux') }
     ....
end
```
```
describe k8s_nodes do
  it { should exist }
  its("names") { should include "foo" }
  its("uids") { should include "6a1a4d2f-0953-4115-8564-acd7bb63a786"}
  its("resource_versions") { should include "161744"}
  ....
end
```

** Has dependency on this PR https://github.com/inspec/inspec-k8s/pull/12 for unit test.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
