### PR TITLE
CFINSPEC-320: Add Kubernetes resources: `k8s_deployment` and `k8s_deployments`

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_deployment.md
+++ b/docs-chef-io/content/inspec/resources/k8s_deployment.md
@@ -1,0 +1,96 @@
++++
+title = "k8s_deployment resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_deployment"
+identifier = "inspec/resources/k8s/K8s Deployment"
+parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_deployment` Chef InSpec audit resource to test the configuration of a specific Deployment in the specified namespace and api.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_deployment(name: 'coredns', namespace: 'kube-system', api: 'apps/v1') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`name`
+: Name of the deployment.
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+`api`
+: API version of the resource (default is **v1**).
+
+## Properties
+
+`uid`
+: UID of the Deployment.
+
+`name`
+: Name of the Deployment.
+
+`namespace`
+: Namespace of the Deployment.
+
+`resource_version`
+: Resource version of the Deployment. This is an alias of `resourceVersion`.
+
+`labels`
+: Labels associated with the Deployment.
+
+`annotations`
+: Annotations associated with the Deployment.
+
+`kind`
+: Resource type of the Deployment.
+
+`creation_timestamp`
+: Creation time of the Deployment. This is an alias of `creationTimestamp`.
+
+`metadata`
+: Metadata for the Deployment.
+
+## Examples
+
+### Deployment for default namespace must exist and test its properties
+
+```ruby
+describe k8s_deployment(name: 'new-deployment', api: 'apps/v1') do
+  it { should exist }
+  its('uid') { should eq 'e948355b-adc2-4db8-af16-34f5aa38d6ec' }
+  its('resource_version') { should eq '8107' }
+  its('labels') { should eq :app=>'new-deployment' }
+  its('annotations') { should_not be_empty }
+  its('name') { should eq 'new-deployment' }
+  its('namespace') { should eq 'default' }
+  its('kind') { should eq 'Deployment' }
+  its('creation_timestamp') { should eq '2022-07-21T18:54:43Z' }
+  its('metadata') { should_not be_nil }
+end
+```
+
+### Deployment for a specified namespace must exist
+
+```ruby
+describe k8s_deployment(namespace: 'kube-system', name: 'coredns', api: 'apps/v1') do
+  it { should exist }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_deployments.md
+++ b/docs-chef-io/content/inspec/resources/k8s_deployments.md
@@ -1,0 +1,85 @@
++++
+title = "k8s_deployments resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_deployments"
+identifier = "inspec/resources/k8s/K8s Deployments"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_deployments` Chef InSpec audit resource to test the configurations of all Deployments in a namespace and api.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_deployments(namespace: 'kube-system', api: 'apps/v1') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+`api`
+: API version of the resource (default is **v1**).
+
+## Properties
+
+`uids`
+: UID of the Deployments.
+
+`names`
+: Name of the Deployments.
+
+`namespaces`
+: Namespace of the Deployments.
+
+`resource_versions`
+: Resource version of the Deployments.
+
+`labels`
+: Labels associated with the Deployments.
+
+`annotations`
+: Annotations associated with the Deployments.
+
+`kinds`
+: Resource type of the Deployments.
+
+## Examples
+
+### Deployments for default namespace must exist
+
+```ruby
+describe k8s_deployments(api: 'apps/v1') do
+  it { should exist }
+  its('names') { should include 'nginx-deployment' }
+end
+```
+
+### Deployments for specified namespace must exist and test its properties
+
+```ruby
+describe k8s_deployments(namespace: 'kube-system', api: 'apps/v1') do
+  it { should exist }
+  its('uids') { should include 'eeb07afc-2f45-4d52-9fda-aa362f7c536c' }
+  its('resource_versions') { should include '7944' }
+  its('labels') { should include :'k8s-app' => 'kube-dns' }
+  its('annotations') { should_not be_empty }
+  its('names') { should include 'coredns' }
+  its('namespaces') { should include 'kube-system' }
+  its('kinds') { should include 'Deployment' }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/libraries/k8s_deployment.rb
+++ b/libraries/k8s_deployment.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_deployment resource to get data about specific kubernetes deployment.
+    class K8sDeployment < K8sObject
+      name 'k8s_deployment'
+      desc 'Verifies settings for a specific deployment'
+
+      example "
+      describe k8s_deployment(name: 'my-deployment', api: 'apps/v1') do
+        it { should exist }
+        its('name') { should eq 'my-deployment' }
+      end
+
+      describe k8s_deployment(namespace: 'default', name: 'new-deployment', api: 'apps/v1') do
+        it { should exist }
+        its('uid') { should eq 'e948355b-adc2-4db8-af16-34f5aa38d6ec' }
+        its('resourceVersion') { should eq '8107' }
+        its('labels') { should eq :app=>'new-deployment' }
+        its('annotations') { should_not be_empty }
+        its('name') { should eq 'new-deployment' }
+        its('namespace') { should eq 'default' }
+        its('kind') { should eq 'Deployment' }
+        its('creation_timestamp') { should eq '2022-07-21T18:54:43Z' }
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'deployments'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8s_deployments.rb
+++ b/libraries/k8s_deployments.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'k8sobjects'
+
+module Inspec
+  module Resources
+    # k8s_deployment resource to get data about specific kubernetes deployment.
+    class K8sDeployments < K8sObjects
+      name 'k8s_deployments'
+      desc 'Verifies settings for all deployments'
+
+      example "
+      describe k8s_deployments(api: 'apps/v1') do
+        it { should exist }
+        its('names') { should include 'nginx-deployment' }
+      end
+
+      describe k8s_deployments(namespace: 'kube-system', api: 'apps/v1') do
+        it { should exist }
+        its('uids') { should include 'eeb07afc-2f45-4d52-9fda-aa362f7c536c' }
+        its('resource_versions') { should include '7944' }
+        its('labels') { should include :'k8s-app' => 'kube-dns' }
+        its('annotations') { should_not be_empty }
+        its('names') { should include 'coredns' }
+        its('namespaces') { should include 'kube-system' }
+        its('kinds') { should include 'Deployment' }
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'deployments'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -48,6 +48,7 @@ module Inspec
       delegate :uid, :name, :namespace, :resourceVersion, :creationTimestamp, to: :metadata
 
       alias resource_version resourceVersion
+      alias creation_timestamp creationTimestamp
 
       def item
         @k8sobject

--- a/test/unit/libraries/k8s_deployment_test.rb
+++ b/test/unit/libraries/k8s_deployment_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sDeploymentTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        deployments: [
+          {
+            name: 'my-deployment',
+            kind: 'Deployment',
+            metadata: {
+              uid: 'e948355b-adc2-4db8-af16-34f5aa38d6ec',
+              name: 'my-deployment',
+              namespace: 'default',
+              resourceVersion: '8107',
+              creationTimestamp: '2022-07-21T18:54:43Z',
+              annotations: { 'deployment.kubernetes.io/revision': '1' },
+              labels: { app: 'my-deployment' }
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'deployments'
+  NAME = 'my-deployment'
+
+  def test_uid
+    assert_equal('e948355b-adc2-4db8-af16-34f5aa38d6ec', k8s_object.uid)
+  end
+
+  def test_resource_version
+    assert_equal('8107', k8s_object.resource_version)
+  end
+
+  def test_labels
+    assert_equal(k8s_object.labels, { app: 'my-deployment' })
+  end
+
+  def test_annotations
+    assert_equal(k8s_object.annotations, { 'deployment.kubernetes.io/revision': '1' })
+  end
+
+  def test_name
+    assert_equal('my-deployment', k8s_object.name)
+  end
+
+  def test_namespace
+    assert_equal('default', k8s_object.namespace)
+  end
+
+  def test_kind
+    assert_equal('Deployment', k8s_object.kind)
+  end
+
+  def test_creation_timestamp
+    assert_equal('2022-07-21T18:54:43Z', k8s_object.creation_timestamp)
+  end
+end

--- a/test/unit/libraries/k8s_deployments_test.rb
+++ b/test/unit/libraries/k8s_deployments_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sPodsTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        deployments: [
+          {
+            name: 'my-deployment',
+            kind: 'Deployment',
+            metadata: {
+              uid: 'e948355b-adc2-4db8-af16-34f5aa38d6ec',
+              name: 'my-deployment',
+              namespace: 'default',
+              resourceVersion: '8107',
+              creationTimestamp: '2022-07-21T18:54:43Z',
+              annotations: { 'deployment.kubernetes.io/revision': '1' },
+              labels: { app: 'my-deployment' }
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'deployments'
+
+  def test_uids
+    assert_includes(k8s_objects.uids, 'e948355b-adc2-4db8-af16-34f5aa38d6ec')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, '8107')
+  end
+
+  def test_labels
+    assert_includes(k8s_objects.labels, { app: 'my-deployment' })
+  end
+
+  def test_annotations
+    assert_includes(k8s_objects.annotations, { 'deployment.kubernetes.io/revision': '1' })
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'my-deployment')
+  end
+
+  def test_namespaces
+    assert_includes(k8s_objects.namespaces, 'default')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'Deployment')
+  end
+end


### PR DESCRIPTION
Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-320: Add Kubernetes resources: `k8s_deployment` and `k8s_deployments`**

## Description
This PR adds the `k8s_deployment` and `k8s_deployments` resources which helps to test the configuration of a specific Deployment (or all Deployments with plural resource i.e. `k8s_deployments`) in the specified namespace and api.

Both the resources use the parent classes (**K8sObject** & **K8sObjects**) to implement their functionalities.

-------------------

### Basic Syntax

- `k8s_deployment`
```ruby
describe k8s_deployment(name: 'coredns', namespace: 'kube-system', api: 'apps/v1') do
  it { should exist }
end
```

- `k8s_deployments`
```ruby
describe k8s_deployments(namespace: 'kube-system', api: 'apps/v1') do
  it { should exist }
end
```

-----------------

### Execute Unit Test

- `k8s_deployment`
```
bundle exec rake test TEST="test/unit/libraries/k8s_deployment_test.rb"
```

- `k8s_deployments`
```
bundle exec rake test TEST="test/unit/libraries/k8s_deployments_test.rb"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
