### PR TITLE
CFINSPEC-322: Add Kubernetes resources: `k8s_namespace` and `k8s_namespaces`

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_namespace.md
+++ b/docs-chef-io/content/inspec/resources/k8s_namespace.md
@@ -1,0 +1,74 @@
++++
+title = "k8s_namespace resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_namespace"
+identifier = "inspec/resources/k8s/K8s Namespace"
+parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_namespace` Chef InSpec audit resource to test the configuration of a specific namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_namespace(name: 'default') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`name`
+: Name of the Namespace.
+
+## Properties
+
+`uid`
+: UID of the Namespace.
+
+`name`
+: Name of the Namespace.
+
+`resource_version`
+: Resource version of the Namespace. This is an alias of `resourceVersion`.
+
+`labels`
+: Labels associated with the Namespace.
+
+`kind`
+: Resource type of the Namespace.
+
+`creation_timestamp`
+: Creation time of the Namespace. This is an alias of `creationTimestamp`.
+
+`metadata`
+: Metadata for the Namespace.
+
+## Examples
+
+### Given namespace must exist and test its properties
+
+```ruby
+describe k8s_namespace(name: 'kube-node-lease') do
+  it { should exist }
+  its('uid') { should eq '5ed76d62-838b-45cb-b41f-789b567a2fa2' }
+  its('name') { should eq 'kube-node-lease' }
+  its('kind') { should eq 'Namespace' }
+  its('resource_version') { should eq '6' }
+  its('creationTimestamp') { should eq '2022-07-21T10:47:49Z' }
+  its('labels') { should eq 'kubernetes.io/metadata.name': 'kube-node-lease' }
+  its('metadata') { should_not be_nil }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_namespaces.md
+++ b/docs-chef-io/content/inspec/resources/k8s_namespaces.md
@@ -1,0 +1,61 @@
++++
+title = "k8s_namespaces resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_namespaces"
+identifier = "inspec/resources/k8s/K8s Namespaces"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_namespaces` Chef InSpec audit resource to test the configurations of all Namespaces.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_namespaces do
+  it { should exist }
+  its('names') { should include 'default' }
+end
+```
+
+## Properties
+
+`uids`
+: UID of the Namespaces.
+
+`names`
+: Name of the Namespaces.
+
+`resource_versions`
+: Resource version of the Namespaces.
+
+`labels`
+: Labels associated with the Namespaces.
+
+`kinds`
+: Resource type of the Namespaces.
+
+## Examples
+
+### Namespaces must exist and test its properties.
+
+```ruby
+describe k8s_namespaces do
+  it { should exist }
+  its('uids') { should include '5ed76d62-838b-45cb-b41f-789b567a2fa2' }
+  its('names') { should include 'default' }
+  its('resource_versions') { should include '6' }
+  its('kinds') { should include 'Namespace' }
+  its('labels') { should include 'kubernetes.io/metadata.name': 'default' }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/libraries/k8s_namespace.rb
+++ b/libraries/k8s_namespace.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_namespace resource to get data about specific kubernetes namespaces.
+    class K8sNamespace < K8sObject
+      DEFAULT_NAMESPACE = nil
+      name 'k8s_namespace'
+      desc 'Verifies settings for a specific namespace'
+
+      example "
+      describe k8s_namespace(name: 'kube-node-lease') do
+        it { should exist }
+        its('uid') { should eq '5ed76d62-838b-45cb-b41f-789b567a2fa2' }
+        its('name') { should eq 'kube-node-lease' }
+        its('kind') { should eq 'Namespace' }
+        its('resource_version') { should eq '6' }
+        its('creationTimestamp') { should eq '2022-07-21T10:47:49Z' }
+        its('labels') { should eq 'kubernetes.io/metadata.name': 'kube-node-lease' }
+        its('metadata') { should_not be_nil }
+      end
+
+      describe k8s_namespace(name: 'default') do
+        it { should exist }
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'namespaces'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8s_namespaces.rb
+++ b/libraries/k8s_namespaces.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_namespaces resource to get data about all kubernetes namespaces.
+    class K8sNamespaces < K8sObjects
+      DEFAULT_NAMESPACE = nil
+      name 'k8s_namespaces'
+      desc 'Verifies settings for a specific deployment'
+
+      example "
+      describe k8s_namespaces do
+        it { should exist }
+        its('uids') { should include '5ed76d62-838b-45cb-b41f-789b567a2fa2' }
+        its('names') { should include 'default' }
+        its('resource_versions') { should include '6' }
+        its('kinds') { should include 'Namespace' }
+        its('labels') { should include 'kubernetes.io/metadata.name': 'default' }
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'namespaces'
+        super(opts)
+      end
+    end
+  end
+end

--- a/test/unit/libraries/k8s_namespace_test.rb
+++ b/test/unit/libraries/k8s_namespace_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sNamespaceTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        namespaces: [
+          {
+            name: 'kube-node-lease',
+            kind: 'Namespace',
+            metadata: {
+              uid: '5ed76d62-838b-45cb-b41f-789b567a2fa2',
+              name: 'kube-node-lease',
+              creationTimestamp: '2022-07-21T10:47:49Z',
+              resourceVersion: '6',
+              labels: { 'kubernetes.io/metadata.name' => 'kube-node-lease' }
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'namespaces'
+  NAME = 'kube-node-lease'
+
+  def test_uid
+    assert_equal('5ed76d62-838b-45cb-b41f-789b567a2fa2', k8s_object.uid)
+  end
+
+  def test_name
+    assert_equal('kube-node-lease', k8s_object.name)
+  end
+
+  def test_kind
+    assert_equal('Namespace', k8s_object.kind)
+  end
+
+  def test_resource_version
+    assert_equal('6', k8s_object.resource_version)
+  end
+
+  def test_labels
+    assert_equal(k8s_object.labels, { 'kubernetes.io/metadata.name': 'kube-node-lease' })
+  end
+
+  def test_creation_timestamp
+    assert_equal(k8s_object.creationTimestamp, '2022-07-21T10:47:49Z')
+  end
+end

--- a/test/unit/libraries/k8s_namespaces_test.rb
+++ b/test/unit/libraries/k8s_namespaces_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sNamespacesTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        namespaces: [
+          {
+            name: 'kube-node-lease',
+            kind: 'Namespace',
+            metadata: {
+              uid: '5ed76d62-838b-45cb-b41f-789b567a2fa2',
+              name: 'kube-node-lease',
+              creationTimestamp: '2022-07-21T10:47:49Z',
+              resourceVersion: '6',
+              labels: { 'kubernetes.io/metadata.name' => 'kube-node-lease' }
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'namespaces'
+
+  def test_uids
+    assert_includes(k8s_objects.uids, '5ed76d62-838b-45cb-b41f-789b567a2fa2')
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'kube-node-lease')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'Namespace')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, '6')
+  end
+
+  def test_labels
+    assert_includes(k8s_objects.labels, { 'kubernetes.io/metadata.name': 'kube-node-lease' })
+  end
+end


### PR DESCRIPTION
Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
CFINSPEC-322: Add Kubernetes resources: `k8s_namespace` and `k8s_namespaces`

## Description
This PR adds the `k8s_namespace` and `k8s_namespaces` resources which helps to test the configuration of a specific namespace (or all namespaces with plural resource i.e. `k8s_namespaces`).

Both the resources use the parent classes (**K8sObject** & **K8sObjects**) to implement their functionalities.

-------------------

### Basic Syntax

- `k8s_namespace`
```ruby
describe k8s_namespace(name: 'default') do
  it { should exist }
end
```

- `k8s_namespaces`
```ruby
describe k8s_namespaces do
  it { should exist }
  its('names') { should include 'default' }
end
```

-----------------

### Execute Unit Test

- `k8s_namespace`
```
bundle exec rake test TEST="test/unit/libraries/k8s_namespace_test.rb"
```

- `k8s_namespaces`
```
bundle exec rake test TEST="test/unit/libraries/k8s_namespaces_test.rb"
```



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
