### PR TITLE
CFINSPEC-322: Add Kubernetes resources: `k8s_cronjob` and `k8s_cronjob`

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_cronjob.md
+++ b/docs-chef-io/content/inspec/resources/k8s_cronjob.md
@@ -1,0 +1,93 @@
++++
+title = "k8s_cronjob resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_cronjob"
+identifier = "inspec/resources/k8s/K8s Cronjob"
+parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_cronjob` Chef InSpec audit resource to test the configuration of a specific Cronjob in the specified namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_cronjob(name: 'hello') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`name`
+: Name of the Cronjob.
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uid`
+: UID of the Cronjob.
+
+`name`
+: Name of the Cronjob.
+
+`namespace`
+: Namespace of the Cronjob.
+
+`resource_version`
+: Resource version of the Cronjob. This is an alias of `resourceVersion`.
+
+`labels`
+: Labels associated with the Cronjob.
+
+`annotations`
+: Annotations associated with the Cronjob.
+
+`kind`
+: Resource type of the Cronjob.
+
+`creation_timestamp`
+: Creation time of the Cronjob. This is an alias of `creationTimestamp`.
+
+`metadata`
+: Metadata for the Cronjob.
+
+## Examples
+
+### Cronjob for default namespace must exist and test its properties
+
+```ruby
+describe k8s_cronjob(name: 'hello') do
+  it { should exist }
+  its('uid') { should eq '378c1a39-cddc-4df6-bf5a-593779eb26fc' }
+  its('resource_version') { should eq '70517' }
+  its('labels') { should be_empty }
+  its('annotations') { should_not be_empty }
+  its('name') { should eq 'hello' }
+  its('namespace') { should eq 'default' }
+  its('kind') { should eq 'CronJob' }
+  its('creationTimestamp') { should eq '2022-07-27T12:54:44Z' }
+  its('metadata') { should_not be_nil }
+end
+```
+
+### Cronjob for a specified namespace must exist
+
+```ruby
+describe k8s_cronjob(name: 'hello-world', namespace: 'my-namespace') do
+  it { should exist }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_cronjobs.md
+++ b/docs-chef-io/content/inspec/resources/k8s_cronjobs.md
@@ -1,0 +1,82 @@
++++
+title = "k8s_cronjobs resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_cronjobs"
+identifier = "inspec/resources/k8s/K8s Cronjobs"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_cronjobs` Chef InSpec audit resource to test the configurations of all Cronjobs in a namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_cronjobs do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uids`
+: UID of the Cronjobs.
+
+`names`
+: Name of the Cronjobs.
+
+`namespaces`
+: Namespace of the Cronjobs.
+
+`resource_versions`
+: Resource version of the Cronjobs.
+
+`labels`
+: Labels associated with the Cronjobs.
+
+`annotations`
+: Annotations associated with the Cronjobs.
+
+`kinds`
+: Resource type of the Cronjobs.
+
+## Examples
+
+### Cronjobs for default namespace must exist and test its properties
+
+```ruby
+describe k8s_cronjobs do
+  it { should exist }
+  its("names") { should include "hello" }
+  its('uids') { should include '378c1a39-cddc-4df6-bf5a-593779eb26fc' }
+  its('namespaces') { should include 'default' }
+  its('resource_versions') { should include '70517' }
+  its('kinds') { should include 'CronJob' }
+  its('labels') { should be_empty }
+  its('annotations') { should_not be_empty }
+end
+```
+
+### Cronjobs for specified namespace must exist
+
+```ruby
+describe k8s_cronjobs(namespace: 'my-namespace') do
+  it { should exist }
+  its("names") { should include "hello-world" }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_cronjobs.md
+++ b/docs-chef-io/content/inspec/resources/k8s_cronjobs.md
@@ -58,7 +58,7 @@ end
 ```ruby
 describe k8s_cronjobs do
   it { should exist }
-  its("names") { should include "hello" }
+  its('names') { should include 'hello' }
   its('uids') { should include '378c1a39-cddc-4df6-bf5a-593779eb26fc' }
   its('namespaces') { should include 'default' }
   its('resource_versions') { should include '70517' }
@@ -73,7 +73,7 @@ end
 ```ruby
 describe k8s_cronjobs(namespace: 'my-namespace') do
   it { should exist }
-  its("names") { should include "hello-world" }
+  its('names') { should include 'hello-world' }
 end
 ```
 

--- a/libraries/k8s_cronjob.rb
+++ b/libraries/k8s_cronjob.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_cronjob resource to get data about specific cronjob in given kubernetes namespace.
+    class K8sCronjob < K8sObject
+      name 'k8s_cronjob'
+      desc 'Verifies settings for a specific cronjob'
+
+      example "
+      describe k8s_cronjob(name: 'hello') do
+        it { should exist }
+        its('uid') { should eq '378c1a39-cddc-4df6-bf5a-593779eb26fc' }
+        its('resource_version') { should eq '70517' }
+        its('labels') { should be_empty }
+        its('annotations') { should_not be_empty }
+        its('name') { should eq 'hello' }
+        its('namespace') { should eq 'default' }
+        its('kind') { should eq 'CronJob' }
+        its('creationTimestamp') { should eq '2022-07-27T12:54:44Z' }
+      end
+
+      describe k8s_cronjob(name: 'hello-world', namespace: 'my-namespace') do
+        it { should exist }
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'cronjobs'
+        opts[:api] = 'batch/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8s_cronjobs.rb
+++ b/libraries/k8s_cronjobs.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'k8sobjects'
+
+module Inspec
+  module Resources
+    # k8s_cronjobs resource to get data about all kubernetes cronjobs.
+    class K8sCronjobs < K8sObjects
+      name 'k8s_cronjobs'
+      desc 'Verifies settings for all cronjobs'
+
+      example "
+      describe k8s_cronjobs do
+        it { should exist }
+        its('names') { should include 'hello' }
+        its('uids') { should include '378c1a39-cddc-4df6-bf5a-593779eb26fc' }
+      end
+
+      describe k8s_cronjobs(namespace: 'my-namespace') do
+        it { should exist }
+        its('names') { should include 'hello-world' }
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'cronjobs'
+        opts[:api] = 'batch/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/test/unit/libraries/k8s_cronjob_test.rb
+++ b/test/unit/libraries/k8s_cronjob_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sCronjobTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        cronjobs: [
+          {
+            name: 'hello',
+            kind: 'Cronjob',
+            metadata: {
+              uid: '378c1a39-cddc-4df6-bf5a-593779eb26fc',
+              name: 'hello',
+              namespace: 'default',
+              resourceVersion: '1234',
+              creationTimestamp: '2022-07-21T10:47:49Z',
+              annotations: { 'test_annotation1': 'abc' },
+              labels: {}
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  NAME = 'hello'
+  TYPE = 'cronjobs'
+
+  def test_uid
+    assert_equal('378c1a39-cddc-4df6-bf5a-593779eb26fc', k8s_object.uid)
+  end
+
+  def test_name
+    assert_equal('hello', k8s_object.name)
+  end
+
+  def test_namespace
+    assert_equal('default', k8s_object.namespace)
+  end
+
+  def test_kind
+    assert_equal('Cronjob', k8s_object.kind)
+  end
+
+  def test_resource_version
+    assert_equal('1234', k8s_object.resource_version)
+  end
+
+  def test_labels
+    assert_equal(k8s_object.labels, {})
+  end
+
+  def test_annotations
+    assert_equal(k8s_object.annotations, { 'test_annotation1': 'abc' })
+  end
+
+  def test_creation_timestamp
+    assert_equal('2022-07-21T10:47:49Z', k8s_object.creationTimestamp)
+  end
+end

--- a/test/unit/libraries/k8s_cronjobs_test.rb
+++ b/test/unit/libraries/k8s_cronjobs_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sCronjobsTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        cronjobs: [
+          {
+            name: 'hello',
+            kind: 'Cronjob',
+            metadata: {
+              uid: '378c1a39-cddc-4df6-bf5a-593779eb26fc',
+              name: 'hello',
+              namespace: 'default',
+              resourceVersion: '1234',
+              creationTimestamp: '2022-07-21T10:47:49Z',
+              annotations: { 'test_annotation1': 'abc' },
+              labels: {}
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'cronjobs'
+
+  def test_uids
+    assert_includes(k8s_objects.uids, '378c1a39-cddc-4df6-bf5a-593779eb26fc')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, '1234')
+  end
+
+  def test_labels
+    assert_includes(k8s_objects.labels, {})
+  end
+
+  def test_annotations
+    assert_includes(k8s_objects.annotations, { 'test_annotation1': 'abc' })
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'hello')
+  end
+
+  def test_namespaces
+    assert_includes(k8s_objects.namespaces, 'default')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'Cronjob')
+  end
+end


### PR DESCRIPTION
Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-322: Add Kubernetes resources: `k8s_cronjob` and `k8s_cronjob`**

## Description
This PR adds the `k8s_cronjob` and `k8s_cronjobs` resources which helps to test the configuration of cronjob in a specific namespace (or in all namespaces with plural resource i.e. `k8s_cronjobs`).

Both the resources use the parent classes (**K8sObject** & **K8sObjects**) to implement their functionalities.

-------------------

### Basic Syntax

- `k8s_cronjob`
```ruby
describe k8s_cronjob(name: 'hello') do
  it { should exist }
end
```

- `k8s_cronjobs`
```ruby
describe k8s_cronjobs do
  it { should exist }
  its('names') { should include 'hello' }
end
```

-----------------

### Execute Unit Test

- `k8s_cronjob`
```
bundle exec rake test TEST="test/unit/libraries/k8s_cronjob_test.rb"
```

- `k8s_cronjobs`
```
bundle exec rake test TEST="test/unit/libraries/k8s_cronjobs_test.rb"
```



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
