### PR TITLE
CFINSPEC-319: Add Kubernetes resources: `k8s_daemon_set` and `k8s_daemon_sets`

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_daemon_set.md
+++ b/docs-chef-io/content/inspec/resources/k8s_daemon_set.md
@@ -1,0 +1,92 @@
++++
+title = "k8s_daemon_set resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_daemon_set"
+identifier = "inspec/resources/k8s/K8s DaemonSet"
+parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_daemon_set` Chef InSpec audit resource to test the configuration of a specific DaemonSet in the specified namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_daemon_set(namespace: 'kube-system', name: 'fluentd-elasticsearch') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`name`
+: Name of the DaemonSet.
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uid`
+: UID of the DaemonSet.
+
+`name`
+: Name of the DaemonSet.
+
+`namespace`
+: Namespace of the DaemonSet.
+
+`resource_version`
+: Resource version of the DaemonSet. This is an alias of `resourceVersion`.
+
+`labels`
+: Labels associated with the DaemonSet.
+
+`annotations`
+: Annotations associated with the DaemonSet.
+
+`kind`
+: Resource type of the DaemonSet.
+
+`creation_timestamp`
+: Creation time of the DaemonSet. This is an alias of `creationTimestamp`.
+
+`metadata`
+: Metadata for the DaemonSet.
+
+## Examples
+
+### DaemonSet for default namespace must exist and test its properties
+
+```ruby
+describe k8s_daemon_set(name: 'fluentd-elasticsearch') do
+  it { should exist }
+  its('uid') { should eq '406b569d-d4f9-4537-b047-cf35b00e88b4' }
+  its('resource_version') { should eq '101377' }
+  its('labels') { should eq 'k8s-app':'fluentd-logging' }
+  its('annotations') { should_not be_empty }
+  its('name') { should eq 'fluentd-elasticsearch' }
+  its('namespace') { should eq 'default' }
+  its('kind') { should eq 'DaemonSet' }
+  its('creation_timestamp') { should eq '2022-07-31T16:41:21Z' }
+end
+```
+
+### DaemonSet for a specified namespace must exist
+
+```ruby
+describe k8s_daemon_set(namespace: 'kube-system', name: 'fluentd-elasticsearch') do
+  it { should exist }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_daemon_sets.md
+++ b/docs-chef-io/content/inspec/resources/k8s_daemon_sets.md
@@ -1,0 +1,82 @@
++++
+title = "k8s_daemon_sets resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_daemon_sets"
+identifier = "inspec/resources/k8s/K8s DaemonSets"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_daemon_sets` Chef InSpec audit resource to test the configurations of all DaemonSets in a namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_daemon_sets(namespace: 'kube-system') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uids`
+: UID of the DaemonSets.
+
+`names`
+: Name of the DaemonSets.
+
+`namespaces`
+: Namespace of the DaemonSets.
+
+`resource_versions`
+: Resource version of the DaemonSets.
+
+`labels`
+: Labels associated with the DaemonSets.
+
+`annotations`
+: Annotations associated with the DaemonSets.
+
+`kinds`
+: Resource type of the DaemonSets.
+
+## Examples
+
+### DaemonSets for default namespace must exist
+
+```ruby
+describe k8s_daemon_sets do
+  it { should exist }
+  its('names') { should include 'fluentd-elasticsearch' }
+end
+```
+
+### DaemonSets for specified namespace must exist and test its properties
+
+```ruby
+describe k8s_daemon_sets(namespace: 'kube-system') do
+  it { should exist }
+  its('names') { should include 'fluentd-elasticsearch' }
+  its('resource_versions') { should include '101377' }
+  its('labels') { should include 'k8s-app':'fluentd-logging' }
+  its('annotations') { should_not be_empty }
+  its('uids') { should include '406b569d-d4f9-4537-b047-cf35b00e88b4' }
+  its('namespaces') { should include 'kube-system' }
+  its('kinds') { should include 'DaemonSet' }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/libraries/k8s_daemon_set.rb
+++ b/libraries/k8s_daemon_set.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_daemon_set resource to get data about specific kubernetes daemonset.
+    class K8sDaemonSet < K8sObject
+      name 'k8s_daemon_set'
+      desc 'Verifies settings for a specific daemonset'
+
+      example "
+      describe k8s_daemon_set(name: 'fluentd-elasticsearch') do
+        it { should exist }
+        its('uid') { should eq '406b569d-d4f9-4537-b047-cf35b00e88b4' }
+        its('resource_version') { should eq '101377' }
+        its('labels') { should eq 'k8s-app':'fluentd-logging' }
+        its('annotations') { should_not be_empty }
+        its('name') { should eq 'fluentd-elasticsearch' }
+        its('namespace') { should eq 'default' }
+        its('kind') { should eq 'DaemonSet' }
+        its('creation_timestamp') { should eq '2022-07-31T16:41:21Z' }
+      end
+
+      describe k8s_daemon_set(namespace: 'kube-system', name: 'fluentd-elasticsearch') do
+        it { should exist }
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'daemonsets'
+        opts[:api] = 'apps/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8s_daemon_sets.rb
+++ b/libraries/k8s_daemon_sets.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'k8sobjects'
+
+module Inspec
+  module Resources
+    # k8s_daemon_sets resource to get data about all kubernetes daemonsets.
+    class K8sDaemonSets < K8sObjects
+      name 'k8s_daemon_sets'
+      desc 'Verifies settings for all daemonsets'
+
+      example "
+      describe k8s_daemon_sets do
+        it { should exist }
+        its('names') { should include 'fluentd-elasticsearch' }
+        its('resource_versions') { should include '101377' }
+        its('labels') { should include 'k8s-app':'fluentd-logging' }
+        its('annotations') { should_not be_empty }
+        its('uids') { should include '406b569d-d4f9-4537-b047-cf35b00e88b4' }
+        its('namespaces') { should include 'default' }
+        its('kinds') { should include 'DaemonSet' }
+      end
+
+      describe k8s_daemon_sets(namespace: 'kube-system') do
+        it { should exist }
+        its('names') { should include 'fluentd-elasticsearch' }
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'daemonsets'
+        opts[:api] = 'apps/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/test/unit/libraries/k8s_daemon_set_test.rb
+++ b/test/unit/libraries/k8s_daemon_set_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sDaemonSetTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        daemonsets: [
+          {
+            name: 'fluentd-elasticsearch',
+            kind: 'DaemonSet',
+            metadata: {
+              uid: 'b7dace1e-138a-4527-ad15-86674f52b609',
+              name: 'fluentd-elasticsearch',
+              namespace: 'default',
+              resourceVersion: '40328',
+              creationTimestamp: '2022-07-21T18:54:43Z',
+              annotations: { 'deprecated.daemonset.template.generation': '1' },
+              labels: { 'k8s-app': 'fluentd-logging' }
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'daemonsets'
+  NAME = 'fluentd-elasticsearch'
+
+  def test_uid
+    assert_equal('b7dace1e-138a-4527-ad15-86674f52b609', k8s_object.uid)
+  end
+
+  def test_resource_version
+    assert_equal('40328', k8s_object.resource_version)
+  end
+
+  def test_labels
+    assert_equal(k8s_object.labels, { 'k8s-app': 'fluentd-logging' })
+  end
+
+  def test_annotations
+    assert_equal(k8s_object.annotations, { 'deprecated.daemonset.template.generation': '1' })
+  end
+
+  def test_name
+    assert_equal('fluentd-elasticsearch', k8s_object.name)
+  end
+
+  def test_namespace
+    assert_equal('default', k8s_object.namespace)
+  end
+
+  def test_kind
+    assert_equal('DaemonSet', k8s_object.kind)
+  end
+
+  def test_creation_timestamp
+    assert_equal('2022-07-21T18:54:43Z', k8s_object.creation_timestamp)
+  end
+end

--- a/test/unit/libraries/k8s_daemon_sets_test.rb
+++ b/test/unit/libraries/k8s_daemon_sets_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sDaemonSetsTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        daemonsets: [
+          {
+            name: 'fluentd-elasticsearch',
+            kind: 'DaemonSet',
+            metadata: {
+              uid: 'b7dace1e-138a-4527-ad15-86674f52b609',
+              name: 'fluentd-elasticsearch',
+              namespace: 'default',
+              resourceVersion: '40328',
+              annotations: { 'deprecated.daemonset.template.generation': '1' },
+              labels: { 'k8s-app': 'fluentd-logging' }
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'daemonsets'
+
+  def test_uids
+    assert_includes(k8s_objects.uids, 'b7dace1e-138a-4527-ad15-86674f52b609')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, '40328')
+  end
+
+  def test_labels
+    assert_includes(k8s_objects.labels, { 'k8s-app': 'fluentd-logging' })
+  end
+
+  def test_annotations
+    assert_includes(k8s_objects.annotations, { 'deprecated.daemonset.template.generation': '1' })
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'fluentd-elasticsearch')
+  end
+
+  def test_namespaces
+    assert_includes(k8s_objects.namespaces, 'default')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'DaemonSet')
+  end
+end


### PR DESCRIPTION
Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-319: Add Kubernetes resources: `k8s_daemon_set` and `k8s_daemon_sets`**

## Description
This PR adds the `k8s_daemon_set` and `k8s_daemon_sets` resources which helps to test the configuration of a specific daemon set (or all daemon sets with plural resource i.e. `k8s_daemon_sets`).

Both the resources use the parent classes (**K8sObject** & **K8sObjects**) to implement their functionalities.

-------------------

### Basic Syntax

- `k8s_daemon_set`
```ruby
describe k8s_daemon_set(namespace: 'kube-system', name: 'fluentd-elasticsearch') do
  it { should exist }
end
```

- `k8s_daemon_sets`
```ruby
describe k8s_daemon_sets(namespace: 'kube-system') do
  it { should exist }
end
```

-----------------

### Execute Unit Test

- `k8s_daemon_set`
```
bundle exec rake test TEST="test/unit/libraries/k8s_daemon_set_test.rb"
```

- `k8s_daemon_sets`
```
bundle exec rake test TEST="test/unit/libraries/k8s_daemon_sets_test.rb"
```



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
