### PR TITLE
CFINSPEC-323: Add Kubernetes resources: `k8s_network_policy` and `k8s_network_policies`

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_network_policies.md
+++ b/docs-chef-io/content/inspec/resources/k8s_network_policies.md
@@ -1,0 +1,84 @@
++++
+title = "k8s_network_policies resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_network_policies"
+identifier = "inspec/resources/k8s/K8s NetworkPolicies"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_network_policies` Chef InSpec audit resource to test the configurations of all network policies in a namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_network_policies do
+  it { should exist }
+  its('names') { should include 'my-network-policy' }
+end
+```
+
+## Parameter
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uids`
+: UID of the Network Policies.
+
+`names`
+: Name of the Network Policies.
+
+`namespaces`
+: Namespace of the Network Policies.
+
+`resource_versions`
+: Resource version of the Network Policies.
+
+`labels`
+: Labels associated with the Network Policies.
+
+`annotations`
+: Annotations associated with the Network Policies.
+
+`kinds`
+: Resource type of the Network Policies.
+
+## Examples
+
+### NetworkPolicies for default namespace must exist
+
+```ruby
+describe k8s_network_policies do
+  it { should exist }
+  its('names') { should include 'my-network-policy' }
+end
+```
+
+### NetworkPolicies for specified namespace must exist and test its properties
+
+```ruby
+describe k8s_network_policies(namespace: 'my-namespace') do
+  it { should exist }
+  its('names') { should include 'test-network-policy' }
+  its('uids') { should include '0beb1fc6-8af7-4607-b3c0-2bff65d4abd6' }
+  its('resource_versions') { should include '129558' }
+  its('labels') { should_not be_empty }
+  its('annotations') { should_not be_empty }
+  its('namespaces') { should include 'my-namespace' }
+  its('kinds') { should include 'NetworkPolicy' }
+  its('metadata') { should_not be_nil }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_network_policy.md
+++ b/docs-chef-io/content/inspec/resources/k8s_network_policy.md
@@ -1,0 +1,93 @@
++++
+title = "k8s_network_policy resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_network_policy"
+identifier = "inspec/resources/k8s/K8s Network Policy"
+parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_network_policy` Chef InSpec audit resource to test the configuration of a specific Network Policy in the specified namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_network_policy(name: 'coredns', namespace: 'kube-system') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`name`
+: Name of the Network Policy.
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uid`
+: UID of the Network Policy.
+
+`name`
+: Name of the Network Policy.
+
+`namespace`
+: Namespace of the Network Policy.
+
+`resource_version`
+: Resource version of the Network Policy. This is an alias of `resourceVersion`.
+
+`labels`
+: Labels associated with the Network Policy.
+
+`annotations`
+: Annotations associated with the Network Policy.
+
+`kind`
+: Resource type of the Network Policy.
+
+`creation_timestamp`
+: Creation time of the Network Policy. This is an alias of `creationTimestamp`.
+
+`metadata`
+: Metadata for the Network Policy.
+
+## Examples
+
+### Network Policy for default namespace must exist and test its properties
+
+```ruby
+describe k8s_network_policy(name: "test-network-policy") do
+  it { should exist }
+  its('uid') { should eq '0beb1fc6-8af7-4607-b3c0-2bff65d4abd6' }
+  its('resource_version') { should eq '129558' }
+  its('labels') { should be_empty }
+  its('annotations') { should_not be_empty }
+  its('name') { should eq 'test-network-policy' }
+  its('namespace') { should eq 'default' }
+  its('kind') { should eq 'NetworkPolicy' }
+  its('creation_timestamp') { should eq '2022-08-02T09:47:56Z' }
+  its('metadata') { should_not be_nil }
+end
+```
+
+### Network Policy for a specified namespace must exist
+
+```ruby
+describe k8s_network_policy(namespace: 'my-namespace', name: 'my-network-policy') do
+  it { should exist }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/libraries/k8s_network_policies.rb
+++ b/libraries/k8s_network_policies.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'k8sobjects'
+
+module Inspec
+  module Resources
+    # k8s_network_policies resource to get data about all kubernetes network policies.
+    class K8sNetworkPolicies < K8sObjects
+      name 'k8s_network_policies'
+      desc 'Verifies settings for all networkpolicies'
+
+      example "
+      describe k8s_network_policies do
+        it { should exist }
+        its('names') { should include 'test-network-policy' }
+        its('uids') { should include '0beb1fc6-8af7-4607-b3c0-2bff65d4abd6' }
+        its('resource_versions') { should include '129558' }
+        its('labels') { should_not be_empty }
+        its('annotations') { should_not be_empty }
+        its('namespaces') { should include 'default' }
+        its('kinds') { should include 'NetworkPolicy' }
+        its('metadata') { should_not be_nil }
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'networkpolicies'
+        opts[:api] = 'networking.k8s.io/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8s_network_policy.rb
+++ b/libraries/k8s_network_policy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_network_policy resource class to get information about specific Kubernetes network-policy in given namespace.
+    class K8sNetworkPolicy < K8sObject
+      name 'k8s_network_policy'
+      desc 'Verifies settings for a specific network-policy'
+
+      example "
+      describe k8s_network_policy(name: 'test-network-policy') do
+        it { should exist }
+        its('uid') { should eq '0beb1fc6-8af7-4607-b3c0-2bff65d4abd6' }
+        its('resource_version') { should eq '129558' }
+        its('labels') { should be_empty }
+        its('annotations') { should_not be_empty }
+        its('name') { should eq 'test-network-policy' }
+        its('namespace') { should eq 'default' }
+        its('kind') { should eq 'NetworkPolicy' }
+        its('creation_timestamp') { should eq '2022-08-02T09:47:56Z' }
+        its('metadata') { should_not be_nil }
+      end
+
+      describe k8s_network_policy(name: 'my-network-policy', namespace: 'my-namespace') do
+        it { should exist }
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'networkpolicies'
+        opts[:api] = 'networking.k8s.io/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/test/unit/libraries/k8s_network_policies_test.rb
+++ b/test/unit/libraries/k8s_network_policies_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sNetworkPoliciesTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        networkpolicies: [
+          {
+            name: 'my-network-policy',
+            kind: 'NetworkPolicy',
+            metadata: {
+              uid: '0beb1fc6-8af7-4607-b3c0-2bff65d4abd6',
+              name: 'my-network-policy',
+              namespace: 'default',
+              resourceVersion: '129558',
+              creationTimestamp: '2022-08-02T09:47:56Z',
+              annotations: {
+                'kubectl.kubernetes.io/last-applied-configuration': '{apiVersion: \'networking.k8s.io/v1\'}'
+              },
+              labels: {}
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'networkpolicies'
+
+  def test_uids
+    assert_includes(k8s_objects.uids, '0beb1fc6-8af7-4607-b3c0-2bff65d4abd6')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, '129558')
+  end
+
+  def test_labels
+    assert_includes(k8s_objects.labels, {})
+  end
+
+  def test_annotations
+    assert_includes(k8s_objects.annotations,
+                    { 'kubectl.kubernetes.io/last-applied-configuration': '{apiVersion: \'networking.k8s.io/v1\'}' })
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'my-network-policy')
+  end
+
+  def test_namespaces
+    assert_includes(k8s_objects.namespaces, 'default')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'NetworkPolicy')
+  end
+end

--- a/test/unit/libraries/k8s_network_policy_test.rb
+++ b/test/unit/libraries/k8s_network_policy_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sNetworkPolicyTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        networkpolicies: [
+          {
+            name: 'my-network-policy',
+            kind: 'NetworkPolicy',
+            metadata: {
+              uid: '0beb1fc6-8af7-4607-b3c0-2bff65d4abd6',
+              name: 'my-network-policy',
+              namespace: 'default',
+              resourceVersion: '129558',
+              creationTimestamp: '2022-08-02T09:47:56Z',
+              annotations: {
+                'kubectl.kubernetes.io/last-applied-configuration': '{apiVersion: \'networking.k8s.io/v1\'}'
+              },
+              labels: {}
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'networkpolicies'
+  NAME = 'my-network-policy'
+
+  def test_uid
+    assert_equal('0beb1fc6-8af7-4607-b3c0-2bff65d4abd6', k8s_object.uid)
+  end
+
+  def test_resource_version
+    assert_equal('129558', k8s_object.resource_version)
+  end
+
+  def test_labels
+    assert_equal(k8s_object.labels, {})
+  end
+
+  def test_annotations
+    assert_equal(k8s_object.annotations,
+                 { 'kubectl.kubernetes.io/last-applied-configuration': '{apiVersion: \'networking.k8s.io/v1\'}' })
+  end
+
+  def test_name
+    assert_equal('my-network-policy', k8s_object.name)
+  end
+
+  def test_namespace
+    assert_equal('default', k8s_object.namespace)
+  end
+
+  def test_kind
+    assert_equal('NetworkPolicy', k8s_object.kind)
+  end
+
+  def test_creation_timestamp
+    assert_equal('2022-08-02T09:47:56Z', k8s_object.creation_timestamp)
+  end
+end


### PR DESCRIPTION
Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-323: Add Kubernetes resources: `k8s_network_policy` and `k8s_network_policies`**

## Description
This PR adds the `k8s_network_policy` and `k8s_network_policies` resources which helps to test the configuration of a specific network policy(or all policies with plural resource i.e. `k8s_network_policies`).

Both the resources use the parent classes (**K8sObject** & **K8sObjects**) to implement their functionalities.

-------------------

### Basic Syntax

- `k8s_network_policy`
```ruby
describe k8s_network_policy(namespace: 'kube-system', name: 'my-policy') do
  it { should exist }
end
```

- `k8s_network_policies`
```ruby
describe k8s_network_policies(namespace: 'kube-system') do
  it { should exist }
end
```

-----------------

### Execute Unit Test

- `k8s_network_policy`
```
bundle exec rake test TEST="test/unit/libraries/k8s_network_policy_test.rb"
```

- `k8s_network_policies`
```
bundle exec rake test TEST="test/unit/libraries/k8s_network_policies_test.rb"
```



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
