### PR TITLE
CFINSPEC-325 Adds support for RBAC cluster roles

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_role.md
+++ b/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_role.md
@@ -1,0 +1,97 @@
++++
+title = "k8s_rbac_cluster_role resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+  [menu.inspec]
+    title = "k8s_rbac_cluster_role"
+    identifier = "inspec/resources/k8s/K8s Rbac Cluster Role"
+    parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_rbac_cluster_role` Chef InSpec audit resource to test the Role-based access control (RBAC) cluster role settings.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_rbac_cluster_role(namespace: "NAMESPACE", name: "NAME") do
+  #...
+end
+```
+
+## Parameters
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+`name`
+: Cluster role name.
+
+## Properties
+
+`uid`
+: UID of the cluster role.
+
+`kind`
+: Resource type of the cluster role.
+
+`resource_version`
+: Resource version of the cluster role.
+
+`labels`
+: Labels attached to the cluster role.
+
+`annotations`
+: Annotations of the cluster role.
+
+`rules`
+: List of rules set for the cluster role.
+
+`aggregation_rule`
+: Aggregation rule set for the cluster role.
+
+`cluster_role_selectors`
+: List of aggregation rule cluster role selectors set for the cluster role.
+
+`metadata`
+: Metadata of the cluster role.
+
+`creation_timestamp`
+: Creation Timestamp pf the cluster role.
+
+## Examples
+
+### Test to verify that the RBAC cluster role with the specified name exists
+
+```ruby
+describe k8s_rbac_cluster_role(name: "CLUSTER_ROLE_NAME") do
+  it { should exist }
+end
+```
+
+### Test to verify rules set for the specified cluster role
+
+```ruby
+describe k8s_rbac_cluster_role(name: "pod-reader") do
+  it { should exist }
+  its('rules') { should  include apiGroups: [""], resources: ["pods"], verbs: ["get", "list", "watch"] }
+end
+```
+
+### Test to verify aggregation rule is not empty and aggregation rule cluster role selectors have the given value
+
+```ruby
+describe k8s_rbac_cluster_role(name: "monitoring") do
+    its("aggregation_rule") { should_not be_empty }
+    its("cluster_role_selectors") { should include matchLabels: { "rbac.example.com/aggregate-to-monitoring": "true" }  }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_role.md
+++ b/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_role.md
@@ -19,15 +19,12 @@ Use the `k8s_rbac_cluster_role` Chef InSpec audit resource to test the Role-base
 ## Syntax
 
 ```ruby
-describe k8s_rbac_cluster_role(namespace: "NAMESPACE", name: "NAME") do
+describe k8s_rbac_cluster_role(name: "NAME") do
   #...
 end
 ```
 
 ## Parameters
-
-`namespace`
-: Namespace of the resource (default is **default**).
 
 `name`
 : Cluster role name.

--- a/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_role.md
+++ b/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_role.md
@@ -59,7 +59,7 @@ end
 : Metadata of the cluster role.
 
 `creation_timestamp`
-: Creation Timestamp pf the cluster role.
+: Creation timestamp of the cluster role.
 
 ## Examples
 
@@ -80,7 +80,7 @@ describe k8s_rbac_cluster_role(name: "pod-reader") do
 end
 ```
 
-### Test to verify aggregation rule is not empty and aggregation rule cluster role selectors have the given value
+### Test to verify aggregation rule is not empty and cluster role selectors have the specified value
 
 ```ruby
 describe k8s_rbac_cluster_role(name: "monitoring") do

--- a/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_roles.md
+++ b/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_roles.md
@@ -1,0 +1,93 @@
++++
+title = "k8s_rbac_cluster_roles resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+  [menu.inspec]
+    title = "k8s_rbac_cluster_roles"
+    identifier = "inspec/resources/k8s/K8s Rbac Cluster Roles"
+    parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_rbac_cluster_roles` Chef InSpec audit resource to test all the Role-based access control (RBAC) cluster roles.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_rbac_cluster_roles do
+  #...
+end
+```
+
+## Parameters
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uids`
+: UID of the cluster roles.
+
+`kinds`
+: Resource type of the cluster roles.
+
+`resource_versions`
+: Resource version of the cluster role.
+
+`labels`
+: Labels attached to the cluster roles.
+
+`annotations`
+: Annotations of the cluster roles.
+
+`rules`
+: List of rules set for the cluster roles.
+
+`aggregation_rules`
+: Aggregation rule set for the cluster roles.
+
+`cluster_role_selectors`
+: List of aggregation rule cluster role selectors set for the cluster roles.
+
+`metadata`
+: Metadata of the cluster roles.
+
+`creation_timestamps`
+: Creation Timestamp pf the cluster roles.
+
+## Examples
+
+### Test to verify that the RBAC cluster roles
+
+```ruby
+describe k8s_rbac_cluster_roles do
+  it { should exist }
+end
+```
+
+### Test to verify rules set for the specified cluster role
+
+```ruby
+describe k8s_rbac_cluster_roles do
+  its('rules') { should  include apiGroups: [''], resources: ['pods'], verbs: ['get', 'list', 'watch'] }
+end
+```
+
+### Test to verify aggregation rules and aggregation rule cluster role selectors
+
+```ruby
+describe k8s_rbac_cluster_roles do
+    its("aggregation_rules") { should_not be_empty }
+    its("cluster_role_selectors") { should include matchLabels: { "rbac.example.com/aggregate-to-monitoring": 'true' }  }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_roles.md
+++ b/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_roles.md
@@ -11,7 +11,6 @@ platform = "k8s"
     parent = "inspec/resources/k8s"
 +++
 
-
 Use the `k8s_rbac_cluster_roles` Chef InSpec audit resource to test all the Role-based access control (RBAC) cluster roles.
 
 ## Installation
@@ -33,7 +32,7 @@ end
 : Resource type of the cluster roles.
 
 `resource_versions`
-: Resource version of the cluster role.
+: Resource version of the cluster roles.
 
 `labels`
 : Labels attached to the cluster roles.
@@ -54,7 +53,7 @@ end
 : Metadata of the cluster roles.
 
 `creation_timestamps`
-: Creation Timestamp pf the cluster roles.
+: Creation timestamp of the cluster roles.
 
 ## Examples
 

--- a/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_roles.md
+++ b/docs-chef-io/content/inspec/resources/k8s_rbac_cluster_roles.md
@@ -24,11 +24,6 @@ describe k8s_rbac_cluster_roles do
 end
 ```
 
-## Parameters
-
-`namespace`
-: Namespace of the resource (default is **default**).
-
 ## Properties
 
 `uids`

--- a/libraries/k8s_backend.rb
+++ b/libraries/k8s_backend.rb
@@ -31,8 +31,13 @@ class K8sResourceBase < Inspec.resource(1)
     @failed_resource = true
     nil
   rescue ::K8s::Error::NotFound => e
-    error = JSON.parse(e.body)
-    fail_resource error['error']['message']
+    if e.respond_to?(:body)
+      error = JSON.parse(e.body)
+      fail_resource error['error']['message']
+    elsif e.respond_to?(:status)
+      fail_resource e.status.message
+    end
+
     @failed_resource = true
     nil
   rescue ::Excon::Error::Socket => e

--- a/libraries/k8s_rbac_cluster_role.rb
+++ b/libraries/k8s_rbac_cluster_role.rb
@@ -27,19 +27,15 @@ module Inspec
       end
 
       def aggregation_rule
-        resource.aggregationRule.to_h
+        resource&.aggregationRule&.to_h
       end
 
       def cluster_role_selectors
-        return [] if resource.aggregationRule.nil?
-
-        resource.aggregationRule.clusterRoleSelectors.map(&:to_h)
+        resource&.aggregationRule&.clusterRoleSelectors&.map(&:to_h)
       end
 
       def rules
-        return [] if resource.rules.nil?
-
-        resource.rules.map(&:to_h)
+        resource&.rules&.map(&:to_h)
       end
     end
   end

--- a/libraries/k8s_rbac_cluster_role.rb
+++ b/libraries/k8s_rbac_cluster_role.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_rbac_cluster_role resource to get data about specific kubernetes cluster role.
+    class K8sRbacClusterRole < K8sObject
+      DEFAULT_NAMESPACE = nil
+
+      name 'k8s_rbac_cluster_role'
+      desc 'Verifies RBAC cluster role values for secified cluster role.'
+
+      example "
+      describe k8s_rbac_cluster_role(name: 'cluster-role-name') do
+        it { should exist }
+        its('name') { should eq 'cluster-role-name' }
+        ...
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'clusterroles'
+        opts[:api] = 'rbac.authorization.k8s.io/v1'
+        super(opts)
+      end
+
+      def aggregation_rule
+        resource.aggregationRule.to_h
+      end
+
+      def cluster_role_selectors
+        return [] if resource.aggregationRule.nil?
+
+        resource.aggregationRule.clusterRoleSelectors.map(&:to_h)
+      end
+
+      def rules
+        return [] if resource.rules.nil?
+
+        resource.rules.map(&:to_h)
+      end
+    end
+  end
+end

--- a/libraries/k8s_rbac_cluster_roles.rb
+++ b/libraries/k8s_rbac_cluster_roles.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'k8sobjects'
+
+module Inspec
+  module Resources
+    # k8s_rbac_cluster_roles resource to get data about all Kubernetes RBAC cluster roles
+    class K8sRbacClusterRoles < K8sObjects
+      DEFAULT_NAMESPACE = nil
+
+      name 'k8s_rbac_cluster_roles'
+      desc 'Verifies settings for all RBAC cluster roles'
+
+      example "
+      describe k8s_rbac_cluster_roles do
+        it { should exist }
+        its('names') { should include 'cluster-role-name' }
+        its('uids') { should include '6a1a4d2f-0953-4115-8564-acd7bb63a786'}
+        ...
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'clusterroles'
+        opts[:api] = 'rbac.authorization.k8s.io/v1'
+        super(opts)
+      end
+
+      private
+
+      def build_record_from(obj)
+        hash = {
+          rules: obj&.rules&.map(&:to_h),
+          aggregation_rule: obj&.aggregationRule&.to_h,
+          cluster_role_selectors: obj&.aggregationRule&.clusterRoleSelectors&.map(&:to_h)
+        }
+        super.merge!(hash)
+      end
+    end
+  end
+end

--- a/test/mock/k8s/transport.rb
+++ b/test/mock/k8s/transport.rb
@@ -48,9 +48,11 @@ module Mock
         self
       end
 
-      def resource(type, namespace: 'default')
+      # namespace_hash has the key :namespace its value.
+      # if namespace is nil then the hash is empty.
+      def resource(type, namespace_hash = {})
         @type = type
-        @namespace = namespace
+        @namespace = namespace_hash[:namespace]
         self
       end
 
@@ -59,7 +61,11 @@ module Mock
       attr_reader :stub_data, :api_version, :type, :namespace, :raise_errors
 
       def current_data
-        stub_data.send(api_version).send(namespace).send(type) || {}
+        if namespace.nil?
+          stub_data.send(api_version).send(type) || {}
+        else
+          stub_data.send(api_version).send(namespace).send(type) || {}
+        end
       end
     end
   end

--- a/test/shared/examples.rb
+++ b/test/shared/examples.rb
@@ -2,6 +2,8 @@
 
 require 'k8sobject'
 require 'k8sobjects'
+require 'k8s_rbac_cluster_role'
+require 'k8s_rbac_cluster_roles'
 
 module Shared
   module Examples
@@ -18,6 +20,23 @@ module Shared
 
     def k8s_objects
       @k8s_objects ||= Inspec::Resources::K8sObjects.new(
+        backend: Mock::K8s::Transport.new(stub_data: self.class::STUB_DATA),
+        type: self.class::TYPE,
+        namespace: self.class::NAMESPACE
+      )
+    end
+
+    def k8s_rbac_cluster_role
+      @k8s_rbac_cluster_role ||= Inspec::Resources::K8sRbacClusterRole.new(
+        backend: Mock::K8s::Transport.new(stub_data: self.class::STUB_DATA),
+        name: self.class::NAME,
+        type: self.class::TYPE,
+        namespace: self.class::NAMESPACE
+      )
+    end
+
+    def k8s_rbac_cluster_roles
+      @k8s_rbac_cluster_roles ||= Inspec::Resources::K8sRbacClusterRoles.new(
         backend: Mock::K8s::Transport.new(stub_data: self.class::STUB_DATA),
         type: self.class::TYPE,
         namespace: self.class::NAMESPACE

--- a/test/unit/libraries/k8s_rbac_cluster_role_test.rb
+++ b/test/unit/libraries/k8s_rbac_cluster_role_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'resource_test'
 
 class K8sRbacClusterRoleTest < ResourceTest
@@ -14,7 +16,7 @@ class K8sRbacClusterRoleTest < ResourceTest
               resourceVersion: 1234,
               annotations: { annotation1: 'value1' },
               labels: { label1: 'value1' },
-              creationTimestamp: "2022-07-28T10:54:46Z"
+              creationTimestamp: '2022-07-28T10:54:46Z'
             }
           }
         ]
@@ -55,9 +57,9 @@ class K8sRbacClusterRoleTest < ResourceTest
   end
 
   def test_creation_timestam
-    assert_equal("2022-07-28T10:54:46Z", k8s_object.creationTimestamp)
+    assert_equal('2022-07-28T10:54:46Z', k8s_object.creationTimestamp)
   end
 
-  #TODO: Writing test for rules, aggreation_rule is pending as currently we are unable to call those methods using k8s_object.
-  # Need to work on mocking the transport for specific resource.
+  # TODO: Writing test for rules, aggreation_rule is pending as currently we are unable to call those methods
+  # using k8s_object. Need to work on mocking the transport for specific resource.
 end

--- a/test/unit/libraries/k8s_rbac_cluster_role_test.rb
+++ b/test/unit/libraries/k8s_rbac_cluster_role_test.rb
@@ -4,23 +4,27 @@ require_relative 'resource_test'
 
 class K8sRbacClusterRoleTest < ResourceTest
   STUB_DATA = {
-    'v1': {
-      default: {
-        clusterroles: [
-          {
+    'rbac.authorization.k8s.io/v1': {
+      clusterroles: [
+        {
+          name: 'role1',
+          kind: 'ClusterRole',
+          metadata: {
+            uid: 'abcd1234',
             name: 'role1',
-            kind: 'ClusterRole',
-            metadata: {
-              uid: 'abcd1234',
-              name: 'role1',
-              resourceVersion: 1234,
-              annotations: { annotation1: 'value1' },
-              labels: { label1: 'value1' },
-              creationTimestamp: '2022-07-28T10:54:46Z'
-            }
+            resourceVersion: 1234,
+            annotations: { annotation1: 'value1' },
+            labels: { label1: 'value1' },
+            creationTimestamp: '2022-07-28T10:54:46Z'
+          },
+          rules: [
+            { verbs: ['get', 'list', 'watch'] }
+          ],
+          aggregationRule: {
+            clusterRoleSelectors: []
           }
-        ]
-      }
+        }
+      ]
     }
   }.freeze
 
@@ -29,37 +33,46 @@ class K8sRbacClusterRoleTest < ResourceTest
   NAMESPACE = nil
 
   def test_uid
-    assert_equal('abcd1234', k8s_object.uid)
+    assert_equal('abcd1234', k8s_rbac_cluster_role.uid)
   end
 
   def test_kind
-    assert_equal('ClusterRole', k8s_object.kind)
+    assert_equal('ClusterRole', k8s_rbac_cluster_role.kind)
   end
 
   def test_name
-    assert_equal('role1', k8s_object.name)
+    assert_equal('role1', k8s_rbac_cluster_role.name)
   end
 
   def test_namespace
-    assert_nil(k8s_object.namespace)
+    assert_nil(k8s_rbac_cluster_role.namespace)
   end
 
   def test_resource_version
-    assert_equal(1234, k8s_object.resource_version)
+    assert_equal(1234, k8s_rbac_cluster_role.resource_version)
   end
 
   def test_has_label?
-    assert_equal(true, k8s_object.has_label?('label1', 'value1'))
+    assert_equal(true, k8s_rbac_cluster_role.has_label?('label1', 'value1'))
   end
 
   def test_has_annotation?
-    assert_equal(true, k8s_object.has_annotation?('annotation1', 'value1'))
+    assert_equal(true, k8s_rbac_cluster_role.has_annotation?('annotation1', 'value1'))
   end
 
   def test_creation_timestam
-    assert_equal('2022-07-28T10:54:46Z', k8s_object.creationTimestamp)
+    assert_equal('2022-07-28T10:54:46Z', k8s_rbac_cluster_role.creationTimestamp)
   end
 
-  # TODO: Writing test for rules, aggreation_rule is pending as currently we are unable to call those methods
-  # using k8s_object. Need to work on mocking the transport for specific resource.
+  def test_aggregation_rule
+    assert_equal({ clusterRoleSelectors: [] }, k8s_rbac_cluster_role.aggregation_rule)
+  end
+
+  def test_cluster_role_selectors
+    assert_equal([], k8s_rbac_cluster_role.cluster_role_selectors)
+  end
+
+  def test_rules
+    assert_equal([{ verbs: %w[get list watch] }], k8s_rbac_cluster_role.rules)
+  end
 end

--- a/test/unit/libraries/k8s_rbac_cluster_role_test.rb
+++ b/test/unit/libraries/k8s_rbac_cluster_role_test.rb
@@ -1,0 +1,63 @@
+require_relative 'resource_test'
+
+class K8sRbacClusterRoleTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        clusterroles: [
+          {
+            name: 'role1',
+            kind: 'ClusterRole',
+            metadata: {
+              uid: 'abcd1234',
+              name: 'role1',
+              resourceVersion: 1234,
+              annotations: { annotation1: 'value1' },
+              labels: { label1: 'value1' },
+              creationTimestamp: "2022-07-28T10:54:46Z"
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'clusterroles'
+  NAME = 'role1'
+  NAMESPACE = nil
+
+  def test_uid
+    assert_equal('abcd1234', k8s_object.uid)
+  end
+
+  def test_kind
+    assert_equal('ClusterRole', k8s_object.kind)
+  end
+
+  def test_name
+    assert_equal('role1', k8s_object.name)
+  end
+
+  def test_namespace
+    assert_nil(k8s_object.namespace)
+  end
+
+  def test_resource_version
+    assert_equal(1234, k8s_object.resource_version)
+  end
+
+  def test_has_label?
+    assert_equal(true, k8s_object.has_label?('label1', 'value1'))
+  end
+
+  def test_has_annotation?
+    assert_equal(true, k8s_object.has_annotation?('annotation1', 'value1'))
+  end
+
+  def test_creation_timestam
+    assert_equal("2022-07-28T10:54:46Z", k8s_object.creationTimestamp)
+  end
+
+  #TODO: Writing test for rules, aggreation_rule is pending as currently we are unable to call those methods using k8s_object.
+  # Need to work on mocking the transport for specific resource.
+end

--- a/test/unit/libraries/k8s_rbac_cluster_roles_test.rb
+++ b/test/unit/libraries/k8s_rbac_cluster_roles_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sRbacClusterRolesTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        clusterroles: [
+          {
+            name: 'role1',
+            kind: 'ClusterRole',
+            metadata: {
+              uid: 'abcd1234',
+              name: 'role1',
+              resourceVersion: 1234,
+              annotations: { annotation1: 'value1' },
+              labels: { label1: 'value1' },
+              creationTimestamp: '2022-07-28T10:54:46Z'
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'clusterroles'
+  NAMESPACE = nil
+
+  def test_uids
+    assert_includes(k8s_objects.uids, 'abcd1234')
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'role1')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'ClusterRole')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, 1234)
+  end
+
+  def test_labels
+    assert_includes(k8s_objects.labels, { label1: 'value1' })
+  end
+
+  def test_annotations
+    assert_includes(k8s_objects.annotations, { annotation1: 'value1' })
+  end
+
+  # TODO: Writing test for rules, aggreation_rule is pending as currently we are unable to call those methods
+  # using k8s_object. Need to work on mocking the transport for specific resource.
+end

--- a/test/unit/libraries/k8s_rbac_cluster_roles_test.rb
+++ b/test/unit/libraries/k8s_rbac_cluster_roles_test.rb
@@ -4,23 +4,42 @@ require_relative 'resource_test'
 
 class K8sRbacClusterRolesTest < ResourceTest
   STUB_DATA = {
-    'v1': {
-      default: {
-        clusterroles: [
-          {
+    'rbac.authorization.k8s.io/v1': {
+      clusterroles: [
+        {
+          name: 'role1',
+          kind: 'ClusterRole',
+          metadata: {
+            uid: 'abcd1234',
             name: 'role1',
-            kind: 'ClusterRole',
-            metadata: {
-              uid: 'abcd1234',
-              name: 'role1',
-              resourceVersion: 1234,
-              annotations: { annotation1: 'value1' },
-              labels: { label1: 'value1' },
-              creationTimestamp: '2022-07-28T10:54:46Z'
-            }
+            resourceVersion: 1234,
+            annotations: { annotation1: 'value1' },
+            labels: { label1: 'value1' },
+            creationTimestamp: '2022-07-28T10:54:46Z'
+          },
+          rules: [
+            { verbs: ['get', 'list', 'watch'] }
+          ],
+          aggregationRule: {
+            clusterRoleSelectors: []
           }
-        ]
-      }
+        },
+        {
+          name: 'role2',
+          kind: 'ClusterRole',
+          metadata: {
+            uid: 'abcd1235',
+            name: 'role2',
+            resourceVersion: 1235,
+            annotations: { annotation1: 'value1' },
+            labels: { label1: 'value1' },
+            creationTimestamp: '2022-07-28T10:54:46Z'
+          },
+          aggregationRule: {
+            clusterRoleSelectors: [{ foo: 'bar' }]
+          }
+        }
+      ]
     }
   }.freeze
 
@@ -28,29 +47,38 @@ class K8sRbacClusterRolesTest < ResourceTest
   NAMESPACE = nil
 
   def test_uids
-    assert_includes(k8s_objects.uids, 'abcd1234')
+    assert_includes(k8s_rbac_cluster_roles.uids, 'abcd1234')
   end
 
   def test_names
-    assert_includes(k8s_objects.names, 'role1')
+    assert_includes(k8s_rbac_cluster_roles.names, 'role1')
   end
 
   def test_kinds
-    assert_includes(k8s_objects.kinds, 'ClusterRole')
+    assert_includes(k8s_rbac_cluster_roles.kinds, 'ClusterRole')
   end
 
   def test_resource_versions
-    assert_includes(k8s_objects.resource_versions, 1234)
+    assert_includes(k8s_rbac_cluster_roles.resource_versions, 1234)
   end
 
   def test_labels
-    assert_includes(k8s_objects.labels, { label1: 'value1' })
+    assert_includes(k8s_rbac_cluster_roles.labels, { label1: 'value1' })
   end
 
   def test_annotations
-    assert_includes(k8s_objects.annotations, { annotation1: 'value1' })
+    assert_includes(k8s_rbac_cluster_roles.annotations, { annotation1: 'value1' })
   end
 
-  # TODO: Writing test for rules, aggreation_rule is pending as currently we are unable to call those methods
-  # using k8s_object. Need to work on mocking the transport for specific resource.
+  def test_aggregation_rule
+    assert_includes(k8s_rbac_cluster_roles.aggregation_rules, { clusterRoleSelectors: [] })
+  end
+
+  def test_cluster_role_selectors
+    assert_includes(k8s_rbac_cluster_roles.cluster_role_selectors, { foo: 'bar' })
+  end
+
+  def test_rules
+    assert_includes(k8s_rbac_cluster_roles.rules, { verbs: %w[get list watch] })
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This adds `k8s_rbac_cluster_role` and `k8s_rbac_cluster_roles` inspec-k8s resources.

Example:
`k8s_rbac_cluster_role`
```
describe k8s_rbac_cluster_role(name: "monitoring") do
  it { should exist }
  its("name") { should eq "monitoring"}
  its("resource_version") { should cmp 313726}
  its("uid") { should cmp "f8d4c66d-b302-4bc6-9ceb-461d765cccf2" }
  its("creationTimestamp") { should cmp "2022-07-28T10:58:48Z" }
  its("aggregation_rule") { should eq clusterRoleSelectors: [{ matchLabels: { "rbac.example.com/aggregate-to-monitoring": "true" } }] }
  its("aggregation_rule") { should_not be_empty }
  its("cluster_role_selectors") { should include matchLabels: { "rbac.example.com/aggregate-to-monitoring": "true" }  }
  its("rules") { should be nil }
end
```

`k8s_rbac_cluster_roles`
```
describe k8s_rbac_cluster_roles do
  it { should exist }
  its("names") { should include "monitoring" }
  its("uids") { should include "f8d4c66d-b302-4bc6-9ceb-461d765cccf2"}
  its("kinds") { should include "ClusterRole" }
  its("rules") { should_not be_empty }
  its("aggregation_rules") { should include clusterRoleSelectors: [{ matchLabels: { "rbac.example.com/aggregate-to-monitoring": "true" } }] }
  its("cluster_role_selectors") { should include matchLabels: { "rbac.example.com/aggregate-to-monitoring": "true" } }
end
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
