### PR TITLE
CFINSPEC-321 Added Kubernetes resource `k8s_job/s`

### DIFF
--- a/docs-chef-io/content/inspec/resources/k8s_job.md
+++ b/docs-chef-io/content/inspec/resources/k8s_job.md
@@ -1,0 +1,92 @@
++++
+title = "k8s_job resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_job"
+identifier = "inspec/resources/k8s/K8s Job"
+parent = "inspec/resources/k8s"
++++
+
+
+Use the `k8s_job` Chef InSpec audit resource to test the configuration of a specific Job in the specified namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_job(name: 'hello') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`name`
+: Name of the Job.
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uid`
+: UID of the Job.
+
+`name`
+: Name of the Job.
+
+`namespace`
+: Namespace of the Job.
+
+`resource_version`
+: Resource version of the Job. This is an alias of `resourceVersion`.
+
+`labels`
+: Labels associated with the Job.
+
+`annotations`
+: Annotations associated with the Job.
+
+`kind`
+: Resource type of the Job.
+
+`creation_timestamp`
+: Creation time of the Job. This is an alias of `creationTimestamp`.
+
+`metadata`
+: Metadata for the Job.
+
+## Examples
+
+### Job for default namespace must exist and test its properties
+
+```ruby
+describe k8s_job(name: 'pi') do
+  it { should exist }
+  its('uid') { should eq 'a31e4d72-816d-4678-8cda-34973bc7808b' }
+  its('resource_version') { should eq '818' }
+  its('labels') { should_not be_empty }
+  its('annotations') { should_not be_empty }
+  its('name') { should eq 'pi' }
+  its('namespace') { should eq 'default' }
+  its('kind') { should eq 'Job' }
+  its('creation_timestamp') { should eq '2022-08-02T12:05:40Z' }
+end
+```
+
+### Job for a specified namespace must exist
+
+```ruby
+describe k8s_job(name: 'hello-world', namespace: 'my-namespace') do
+  it { should exist }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/docs-chef-io/content/inspec/resources/k8s_jobs.md
+++ b/docs-chef-io/content/inspec/resources/k8s_jobs.md
@@ -1,0 +1,82 @@
++++
+title = "k8s_jobs resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_jobs"
+identifier = "inspec/resources/k8s/K8s Jobs"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_jobs` Chef InSpec audit resource to test the configurations of all Jobs in a namespace.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_jobs do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`namespace`
+: Namespace of the resource (default is **default**).
+
+## Properties
+
+`uids`
+: UID of the Jobs.
+
+`names`
+: Name of the Jobs.
+
+`namespaces`
+: Namespace of the Jobs.
+
+`resource_versions`
+: Resource version of the Jobs.
+
+`labels`
+: Labels associated with the Jobs.
+
+`annotations`
+: Annotations associated with the Jobs.
+
+`kinds`
+: Resource type of the Jobs.
+
+## Examples
+
+### Jobs for default namespace must exist and test its properties
+
+```ruby
+describe k8s_jobs do
+  it { should exist }
+  its('names') { should include 'hello' }
+  its('uids') { should include '378c1a39-cddc-4df6-bf5a-593779eb26fc' }
+  its('namespaces') { should include 'default' }
+  its('resource_versions') { should include '70517' }
+  its('kinds') { should include 'Job' }
+  its('labels') { should_not be_empty }
+  its('annotations') { should_not be_empty }
+end
+```
+
+### Jobs for specified namespace must exist
+
+```ruby
+describe k8s_jobs(namespace: 'my-namespace') do
+  it { should exist }
+  its('names') { should include 'hello-world' }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/libraries/k8s_job.rb
+++ b/libraries/k8s_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'k8sobject'
+
+module Inspec
+  module Resources
+    # k8s_job resource to get data about specific job in given kubernetes namespace.
+    class K8sJob < K8sObject
+      name 'k8s_job'
+      desc 'Verifies settings for a specific job'
+
+      example "
+      describe k8s_job(name: 'pi') do
+        it { should exist }
+        its('uid') { should eq 'a31e4d72-816d-4678-8cda-34973bc7808b' }
+        its('resource_version') { should eq '818' }
+        its('labels') { should_not be_empty }
+        its('annotations') { should_not be_empty }
+        its('name') { should eq 'pi' }
+        its('namespace') { should eq 'default' }
+        its('kind') { should eq 'Job' }
+        its('creation_timestamp') { should eq '2022-08-02T12:05:40Z' }
+      end
+
+      describe k8s_job(name: 'hello-world', namespace: 'my-namespace') do
+        it { should exist }
+      end
+    "
+
+      def initialize(opts = {})
+        Validators.validate_params_required(@__resource_name__, [:name], opts)
+        opts[:type] = 'jobs'
+        opts[:api] = 'batch/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/libraries/k8s_jobs.rb
+++ b/libraries/k8s_jobs.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'k8sobjects'
+
+module Inspec
+  module Resources
+    # k8s_jobs resource to get data about all kubernetes jobs.
+    class K8sJobs < K8sObjects
+      name 'k8s_jobs'
+      desc 'Verifies settings for all jobs'
+
+      example "
+      describe k8s_jobs do
+        it { should exist }
+        its('names') { should include 'pi' }
+        its('names') { should include 'pi-2' }
+        its('uids') { should include 'a31e4d72-816d-4678-8cda-34973bc7808b' }
+      end
+
+      describe k8s_jobs(namespace: 'my-namespace') do
+        it { should exist }
+        its('names') { should include 'hello-world' }
+      end
+    "
+
+      def initialize(opts = {})
+        opts[:type] = 'jobs'
+        opts[:api] = 'batch/v1'
+        super(opts)
+      end
+    end
+  end
+end

--- a/test/unit/libraries/k8s_job_test.rb
+++ b/test/unit/libraries/k8s_job_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sJobTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        jobs: [
+          {
+            name: 'hello',
+            kind: 'Job',
+            metadata: {
+              uid: '378c1a39-cddc-4df6-bf5a-593779eb26fc',
+              name: 'hello',
+              namespace: 'default',
+              resourceVersion: '1234',
+              creationTimestamp: '2022-07-21T10:47:49Z',
+              annotations: { 'test_annotation1': 'abc' },
+              labels: {}
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  NAME = 'hello'
+  TYPE = 'jobs'
+
+  def test_uid
+    assert_equal('378c1a39-cddc-4df6-bf5a-593779eb26fc', k8s_object.uid)
+  end
+
+  def test_name
+    assert_equal('hello', k8s_object.name)
+  end
+
+  def test_namespace
+    assert_equal('default', k8s_object.namespace)
+  end
+
+  def test_kind
+    assert_equal('Job', k8s_object.kind)
+  end
+
+  def test_resource_version
+    assert_equal('1234', k8s_object.resource_version)
+  end
+
+  def test_labels
+    assert_equal(k8s_object.labels, {})
+  end
+
+  def test_annotations
+    assert_equal(k8s_object.annotations, { 'test_annotation1': 'abc' })
+  end
+
+  def test_creation_timestamp
+    assert_equal('2022-07-21T10:47:49Z', k8s_object.creationTimestamp)
+  end
+end

--- a/test/unit/libraries/k8s_jobs_test.rb
+++ b/test/unit/libraries/k8s_jobs_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'resource_test'
+
+class K8sJobsTest < ResourceTest
+  STUB_DATA = {
+    'v1': {
+      default: {
+        jobs: [
+          {
+            name: 'hello',
+            kind: 'Job',
+            metadata: {
+              uid: '378c1a39-cddc-4df6-bf5a-593779eb26fc',
+              name: 'hello',
+              namespace: 'default',
+              resourceVersion: '1234',
+              creationTimestamp: '2022-07-21T10:47:49Z',
+              annotations: { 'test_annotation1': 'abc' },
+              labels: {}
+            }
+          }
+        ]
+      }
+    }
+  }.freeze
+
+  TYPE = 'jobs'
+
+  def test_uids
+    assert_includes(k8s_objects.uids, '378c1a39-cddc-4df6-bf5a-593779eb26fc')
+  end
+
+  def test_resource_versions
+    assert_includes(k8s_objects.resource_versions, '1234')
+  end
+
+  def test_labels
+    assert_includes(k8s_objects.labels, {})
+  end
+
+  def test_annotations
+    assert_includes(k8s_objects.annotations, { 'test_annotation1': 'abc' })
+  end
+
+  def test_names
+    assert_includes(k8s_objects.names, 'hello')
+  end
+
+  def test_namespaces
+    assert_includes(k8s_objects.namespaces, 'default')
+  end
+
+  def test_kinds
+    assert_includes(k8s_objects.kinds, 'Job')
+  end
+end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

## Related Issue
**CFINSPEC-321: Add Kubernetes resources: `k8s_job` and `k8s_jobs`**

## Description
This PR adds the `k8s_job` and `k8s_jobs` resources which help to test the configuration of specific jobs (or all jobs with plural resource i.e. `k8s_jobs`).

Both the resources use the parent classes (**K8sJob** & **K8sJobs**) to implement their functionalities.

-------------------

### Basic Syntax

- `k8s_job`
```ruby
describe k8s_job(namespace: 'default', name: 'hello') do
  it { should exist }
end
```

- `k8s_jobs`
```ruby
describe k8s_jobs(namespace: 'default') do
  it { should exist }
end
```

-----------------

### Execute Unit Test

- `k8s_job`
```
bundle exec rake test TEST="test/unit/libraries/k8s_job_test.rb"
```

- `k8s_jobs`
```
bundle exec rake test TEST="test/unit/libraries/k8s_jobs_test.rb"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
