### PR TITLE
Cfinspec 502 support new k8s File exec resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ describe k8sobject(api: 'v1', type: 'pod', namespace: 'default', name: 'my-pod')
 end
 ```
 
+In order to use file resource against a file inside the pod. This is useful to identify permissions, owner, type etc..
+Currently it supports only Linux based containers.
+```ruby 
+describe k8s_exec_file(path: 'FULLY_QUALIFIED_PATH', pod: 'POD_NAME', namespace: 'NAMESPACE_NAME') do
+  it { should exist }
+  it { should be_file }
+  it { should be_readable }
+  it { should be_writable }
+  it { should be_executable.by_user('root') }
+  it { should be_owned_by 'root' }
+  its('mode') { should cmp '0644' }
+end
+```
+
 ## Preconditions
 
 - Inspec 3.7+ or 4.x+

--- a/docs-chef-io/content/inspec/resources/k8s_exec_file.md
+++ b/docs-chef-io/content/inspec/resources/k8s_exec_file.md
@@ -1,0 +1,96 @@
++++
+title = "k8s_exec_file resource"
+draft = false
+gh_repo = "inspec"
+platform = "k8s"
+
+[menu]
+[menu.inspec]
+title = "k8s_exec_file"
+identifier = "inspec/resources/k8s/K8s Exec File"
+parent = "inspec/resources/k8s"
++++
+
+Use the `k8s_exec_file` Chef InSpec audit resource to test the properties of all files within in a pod/container.
+
+## Installation
+
+## Syntax
+
+```ruby
+describe k8s_exec_file(path: '/etc/e2scrub.conf', pod: 'shell-demo', namespace: 'default') do
+  it { should exist }
+end
+```
+
+## Parameter
+
+`namespace`
+: Namespace of the resource (default: **default**).
+
+`pod`
+: Name of the pod
+
+`path`
+: Fully Qualified path of the file
+
+`container`
+: Name of the container
+
+## Properties
+
+`content`
+: content of the files.
+
+`size`
+: size of the file.
+
+`basename`
+: basename of the file.
+
+`owner`
+: owner of the file.
+
+`group`
+: File group.
+
+`type`
+: file type.
+
+`symlink`
+: symlink directory
+
+`mode`
+: file mode
+
+`uid`
+: UID of the file
+
+## Examples
+
+### Check if path exists and it is a file
+
+```ruby
+describe k8s_exec_file(path: '/etc/e2scrub.conf', pod: 'shell-demo', namespace: 'default') do
+  it { should exist }
+  it { should be_file }
+end
+```
+
+### check if we have full rights on the file
+
+```ruby
+describe k8s_exec_file(path: '/etc/e2scrub.conf', pod: 'shell-demo', namespace: 'default') do
+  it { should exist }
+  it { should be_file }
+  it { should be_readable }
+  it { should be_writable }
+  it { should be_executable.by_user('root') }
+  it { should be_owned_by 'root' }
+  its('mode') { should cmp '0644' }
+end
+```
+
+## Matchers
+
+{{% inspec/inspec_matchers_link %}}

--- a/libraries/k8s_exec_file.rb
+++ b/libraries/k8s_exec_file.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'train-kubernetes/file/linux'
+require 'inspec/resources/file'
+
+module Inspec
+  module Resources
+    class K8sExecFile < ::Inspec::Resources::FileResource
+      attr_reader :opts
+
+      name 'k8s_exec_file'
+      supports platform: 'k8s'
+      desc 'Run a command or script inside a pod.'
+
+      example <<~EXAMPLE
+        describe k8s_exec_file(path: '/etc/e2scrub.conf', pod: 'shell-demo', namespace: 'default') do
+          it { should exist }
+          it { should be_file }
+          it { should be_readable }
+          it { should be_writable }
+          it { should be_executable.by_user('root') }
+          it { should be_owned_by 'root' }
+          its('mode') { should cmp '0644' }
+        end
+      EXAMPLE
+
+      def initialize(opts)
+        @opts = opts
+        @path = opts[:path]
+        @pod = opts[:pod]
+        @container = opts[:container]
+        @namespace = opts[:namespace]
+        Validators.validate_params_required(@__resource_name__, %i[pod path], opts)
+        @file = inspec.backend.file(path, pod: pod, container: container, namespace: namespace)
+        @perms_provider = ::Inspec::Resources::UnixFilePermissions.new(inspec)
+      end
+
+      private
+
+      attr_reader :pod, :container, :namespace, :path
+    end
+  end
+end
+

--- a/libraries/k8s_pod_exec.rb
+++ b/libraries/k8s_pod_exec.rb
@@ -40,10 +40,6 @@ module Inspec
               "Command `#{command}` timed out after #{@timeout} seconds"
       end
 
-      def exit_status
-        result&.exitstatus
-      end
-
       private
 
       attr_reader :pod, :container, :namespace, :command

--- a/libraries/k8s_pod_exec.rb
+++ b/libraries/k8s_pod_exec.rb
@@ -40,6 +40,10 @@ module Inspec
               "Command `#{command}` timed out after #{@timeout} seconds"
       end
 
+      def exit_status
+        result&.exitstatus
+      end
+
       private
 
       attr_reader :pod, :container, :namespace, :command


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Support new k8s pod exec resource 
* in order to access files within the pod 
* file properties and permissions
* see the contents of the file

Currently this resource supports only Linux based Containers

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
