### PR TITLE
CHEF-3447: Fix resource_id to avoid breaking InSpec's reporter such as `json` or `json-automate`

### DIFF
--- a/libraries/k8s_backend.rb
+++ b/libraries/k8s_backend.rb
@@ -6,7 +6,7 @@
 #
 
 require 'json'
-require "inspec/resource"
+require 'inspec/resource'
 
 # Base class for K8s resources - depends on train K8s transport for connection
 class K8sResourceBase < Inspec.resource(1)
@@ -46,6 +46,10 @@ class K8sResourceBase < Inspec.resource(1)
     fail_resource error['error']['message']
     @failed_resource = true
     nil
+  end
+
+  def resource_id
+    'k8s_resource_base'
   end
 end
 

--- a/libraries/k8s_containers.rb
+++ b/libraries/k8s_containers.rb
@@ -44,4 +44,3 @@ module Inspec
     end
   end
 end
-

--- a/libraries/k8s_exec_file.rb
+++ b/libraries/k8s_exec_file.rb
@@ -68,6 +68,8 @@ module Inspec
         end
       end
 
+      # NOTE: Here, the resource_id is used from the parent class.
+
       private
 
       attr_reader :pod, :container, :namespace, :path, :file

--- a/libraries/k8s_pod_exec.rb
+++ b/libraries/k8s_pod_exec.rb
@@ -1,4 +1,5 @@
-# # frozen_string_literal: true
+# frozen_string_literal: true
+
 require 'train-kubernetes/kubectl_client'
 require 'inspec/resources/command'
 module Inspec
@@ -38,6 +39,10 @@ module Inspec
         sleep 0.1
         raise Inspec::Exceptions::ResourceFailed,
               "Command `#{command}` timed out after #{@timeout} seconds"
+      end
+
+      def resource_id
+        opts[:pod] || opts[:container] || opts[:command] || 'k8s_pod_exec'
       end
 
       private

--- a/libraries/k8s_pod_exec.rb
+++ b/libraries/k8s_pod_exec.rb
@@ -42,7 +42,9 @@ module Inspec
       end
 
       def resource_id
-        opts[:pod] || opts[:container] || opts[:command] || 'k8s_pod_exec'
+        # Note: Hashing the command to hide any secrets
+        cmd_hash = Digest::SHA256.hexdigest(command)
+        "#{pod}-#{container}-#{cmd_hash}" || 'k8s_pod_exec'
       end
 
       private

--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -44,8 +44,8 @@ module Inspec
         end
       end
 
-      delegate :kind, :metadata, to: :resource
-      delegate :uid, :name, :namespace, :resourceVersion, :creationTimestamp, to: :metadata
+      delegate :kind, :metadata, to: :resource, allow_nil: true
+      delegate :uid, :name, :namespace, :resourceVersion, :creationTimestamp, to: :metadata, allow_nil: true
 
       alias resource_version resourceVersion
       alias creation_timestamp creationTimestamp

--- a/libraries/k8sobjects.rb
+++ b/libraries/k8sobjects.rb
@@ -76,7 +76,7 @@ module Inspec
       end
 
       def resource_id
-        @objname || @objnamespace || @objtype || 'k8sobjects'
+        "#{@objapi}-#{@objtype}-#{@objname}-#{@obj_label_selector}" || 'k8sobjects'
       end
 
       private

--- a/libraries/k8sobjects.rb
+++ b/libraries/k8sobjects.rb
@@ -75,6 +75,10 @@ module Inspec
         entries
       end
 
+      def resource_id
+        @objname || @objnamespace || @objtype || 'k8sobjects'
+      end
+
       private
 
       def populate_filter_table_from_response

--- a/libraries/k8sversion.rb
+++ b/libraries/k8sversion.rb
@@ -47,5 +47,9 @@ module Inspec::Resources
     def to_s
       @display_name.to_s
     end
+
+    def resource_id
+      @display_name.to_s || 'k8sversion'
+    end
   end
 end

--- a/test/unit/libraries/k8s_api_resources_test.rb
+++ b/test/unit/libraries/k8s_api_resources_test.rb
@@ -47,4 +47,8 @@ class K8sApiResourcesTest < ResourceTest
   def test_categories
     assert_equal(['all'], k8s_api_resources.categories)
   end
+
+  def test_resource_id
+    refute_nil(k8s_api_resources.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_config_map_test.rb
+++ b/test/unit/libraries/k8s_config_map_test.rb
@@ -57,4 +57,8 @@ class K8sConfigMapTest < ResourceTest
   def annotations
     assert_equal(k8s_object.annotations, {})
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_config_maps_test.rb
+++ b/test/unit/libraries/k8s_config_maps_test.rb
@@ -56,4 +56,8 @@ class K8sConfigMapsConstructorTest < ResourceTest
   def test_annotations
     assert_includes(k8s_objects.annotations, {})
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_container_test.rb
+++ b/test/unit/libraries/k8s_container_test.rb
@@ -117,6 +117,10 @@ class K8sContainerTest < ResourceTest
     assert(k8s_object.has_command?('printenv'))
   end
 
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
+
   private
 
   def k8s_object

--- a/test/unit/libraries/k8s_containers_test.rb
+++ b/test/unit/libraries/k8s_containers_test.rb
@@ -108,6 +108,10 @@ class K8sContainersTest < ResourceTest
     assert_includes(k8s_objects.securityContexts.map(&:capabilities).map(&:add).flatten, 'NET_BIND_SERVICE')
   end
 
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
+
   private
 
   def k8s_objects

--- a/test/unit/libraries/k8s_cronjob_test.rb
+++ b/test/unit/libraries/k8s_cronjob_test.rb
@@ -59,4 +59,8 @@ class K8sCronjobTest < ResourceTest
   def test_creation_timestamp
     assert_equal('2022-07-21T10:47:49Z', k8s_object.creationTimestamp)
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_cronjobs_test.rb
+++ b/test/unit/libraries/k8s_cronjobs_test.rb
@@ -54,4 +54,8 @@ class K8sCronjobsTest < ResourceTest
   def test_kinds
     assert_includes(k8s_objects.kinds, 'Cronjob')
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_daemon_set_test.rb
+++ b/test/unit/libraries/k8s_daemon_set_test.rb
@@ -59,4 +59,8 @@ class K8sDaemonSetTest < ResourceTest
   def test_creation_timestamp
     assert_equal('2022-07-21T18:54:43Z', k8s_object.creation_timestamp)
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_daemon_sets_test.rb
+++ b/test/unit/libraries/k8s_daemon_sets_test.rb
@@ -53,4 +53,8 @@ class K8sDaemonSetsTest < ResourceTest
   def test_kinds
     assert_includes(k8s_objects.kinds, 'DaemonSet')
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_deployment_test.rb
+++ b/test/unit/libraries/k8s_deployment_test.rb
@@ -59,4 +59,8 @@ class K8sDeploymentTest < ResourceTest
   def test_creation_timestamp
     assert_equal('2022-07-21T18:54:43Z', k8s_object.creation_timestamp)
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_deployments_test.rb
+++ b/test/unit/libraries/k8s_deployments_test.rb
@@ -54,4 +54,8 @@ class K8sDeploymentsTest < ResourceTest
   def test_kinds
     assert_includes(k8s_objects.kinds, 'Deployment')
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_job_test.rb
+++ b/test/unit/libraries/k8s_job_test.rb
@@ -59,4 +59,8 @@ class K8sJobTest < ResourceTest
   def test_creation_timestamp
     assert_equal('2022-07-21T10:47:49Z', k8s_object.creationTimestamp)
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_jobs_test.rb
+++ b/test/unit/libraries/k8s_jobs_test.rb
@@ -54,4 +54,8 @@ class K8sJobsTest < ResourceTest
   def test_kinds
     assert_includes(k8s_objects.kinds, 'Job')
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_namespace_test.rb
+++ b/test/unit/libraries/k8s_namespace_test.rb
@@ -49,4 +49,8 @@ class K8sNamespaceTest < ResourceTest
   def test_creation_timestamp
     assert_equal(k8s_object.creationTimestamp, '2022-07-21T10:47:49Z')
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_namespaces_test.rb
+++ b/test/unit/libraries/k8s_namespaces_test.rb
@@ -44,4 +44,8 @@ class K8sNamespacesTest < ResourceTest
   def test_labels
     assert_includes(k8s_objects.labels, { 'kubernetes.io/metadata.name': 'kube-node-lease' })
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_network_policies_test.rb
+++ b/test/unit/libraries/k8s_network_policies_test.rb
@@ -57,4 +57,8 @@ class K8sNetworkPoliciesTest < ResourceTest
   def test_kinds
     assert_includes(k8s_objects.kinds, 'NetworkPolicy')
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_network_policy_test.rb
+++ b/test/unit/libraries/k8s_network_policy_test.rb
@@ -62,4 +62,8 @@ class K8sNetworkPolicyTest < ResourceTest
   def test_creation_timestamp
     assert_equal('2022-08-02T09:47:56Z', k8s_object.creation_timestamp)
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_node_test.rb
+++ b/test/unit/libraries/k8s_node_test.rb
@@ -53,4 +53,8 @@ class K8sNodeTest < ResourceTest
   def test_has_annotation?
     assert_equal(true, k8s_object.has_annotation?('annotation1', 'value1'))
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_nodes_test.rb
+++ b/test/unit/libraries/k8s_nodes_test.rb
@@ -64,4 +64,8 @@ class K8sNodesTest < ResourceTest
   def test_annotations_has_given_values
     assert_includes(k8s_objects.annotations, { foo1: 'bar1' })
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_pod_test.rb
+++ b/test/unit/libraries/k8s_pod_test.rb
@@ -57,4 +57,8 @@ class K8sPodTest < ResourceTest
   def test_annotations
     assert_equal(k8s_object.annotations, {})
   end
+
+  def test_resource_id
+    refute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_pods_test.rb
+++ b/test/unit/libraries/k8s_pods_test.rb
@@ -56,4 +56,8 @@ class K8sPodsTest < ResourceTest
   def test_annotations
     assert_includes(k8s_objects.annotations, {})
   end
+
+  def test_resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_rbac_cluster_role_test.rb
+++ b/test/unit/libraries/k8s_rbac_cluster_role_test.rb
@@ -75,4 +75,8 @@ class K8sRbacClusterRoleTest < ResourceTest
   def test_rules
     assert_equal([{ verbs: %w[get list watch] }], k8s_rbac_cluster_role.rules)
   end
+
+  def test_resource_id
+    refute_nil(k8s_rbac_cluster_role.resource_id)
+  end
 end

--- a/test/unit/libraries/k8s_rbac_cluster_roles_test.rb
+++ b/test/unit/libraries/k8s_rbac_cluster_roles_test.rb
@@ -81,4 +81,8 @@ class K8sRbacClusterRolesTest < ResourceTest
   def test_rules
     assert_includes(k8s_rbac_cluster_roles.rules, { verbs: %w[get list watch] })
   end
+
+  def test_resource_id
+    refute_nil(k8s_rbac_cluster_roles.resource_id)
+  end
 end

--- a/test/unit/libraries/k8sobject_test.rb
+++ b/test/unit/libraries/k8sobject_test.rb
@@ -68,4 +68,8 @@ class K8sObjectTest < ResourceTest
   def test_resource_id
     assert_equal('abcd1234', k8s_object.resource_id)
   end
+
+  def resource_id
+    retute_nil(k8s_object.resource_id)
+  end
 end

--- a/test/unit/libraries/k8sobjects_test.rb
+++ b/test/unit/libraries/k8sobjects_test.rb
@@ -70,4 +70,8 @@ class K8sObjectsTest < ResourceTest
   def test_annotations
     assert_includes(k8s_objects.annotations, { test_annotation1: 'foo' })
   end
+
+  def resource_id
+    refute_nil(k8s_objects.resource_id)
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes the delegation error raised when k8sobject (aka resource) is nil and an attempt is made to fetch the `uid` in `resource_id`. Therefore, it breaks reporter like `json` or `json-automate`

(Note: `uid` is delegated to `metadata`; and `metadata` is delegated to `resource`; and `resource` is alias for `k8sobject`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-3447: InSpec K8S resources with Automate reporter generate exceptions
CHEF-3929: inspec-k8s resource ids do not work with Automate reporter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
