### PR TITLE
Fix ActiveSupport's `undefined method deprecator for ActiveSupport:Module (NoMethodError)` issue

### DIFF
--- a/libraries/k8sobject.rb
+++ b/libraries/k8sobject.rb
@@ -2,6 +2,7 @@
 
 require 'k8s_backend'
 require 'pry'
+require 'active_support'
 require 'active_support/core_ext/module/delegation'
 
 module Inspec

--- a/libraries/k8sobjects.rb
+++ b/libraries/k8sobjects.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'k8s_backend'
+require 'active_support'
 require 'active_support/core_ext/string'
 
 module Inspec

--- a/test/unit/libraries/resource_test.rb
+++ b/test/unit/libraries/resource_test.rb
@@ -1,4 +1,5 @@
 require_relative '../../test_helper'
+require 'active_support'
 require 'active_support/core_ext/hash/indifferent_access'
 require_relative '../../shared/examples'
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes the issue raised by ActiveSupport when using `activesupport-7.1.1`. The error results is:
```
/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/activesupport-7.1.1/lib/active_support/core_ext/array/conversions.rb:108:in `<class:Array>': undefined method `deprecator' for ActiveSupport:Module (NoMethodError)

  deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
                                                          ^^^^^^^^^^^
Did you mean?  deprecate_constant
```

The issue is caused because of not requiring `active_support` before requiring anything inside of `active_support`

Read more about the issue here:
https://github.com/inspec/train/pull/751
https://github.com/rails/rails/issues/49495#issuecomment-1749085658

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/rails/rails/issues/49495
https://github.com/inspec/train/issues/750

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
