### PR TITLE
CHEF-27131 - Create CODE_OF_CONDUCT.md file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Chef Code of Conduct
+
+Participants in this project must adhere to the [Chef Code of Conduct](https://chef.github.io/chef-oss-practices/policies/code-of-conduct/).


### PR DESCRIPTION
As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025) we are standardizing all repos to have a standard CODE_OF_CONDUCT.md file that points to the main Chef Code of Conduct. This is not intended to be a change in policy, but rather an administrative change.